### PR TITLE
Feature/ingest s3 labels

### DIFF
--- a/croissant/ingest.py
+++ b/croissant/ingest.py
@@ -1,0 +1,145 @@
+from typing import Optional, Any, Union, List, Tuple
+from pathlib import Path
+import pandas as pd
+from functools import partial
+
+from croissant.utils import (
+    read_jsonlines, s3_get_object, nested_get_item)
+
+
+def annotation_df_from_file(
+        filepath: Union[str, Path],
+        project_key: str,
+        label_key: str,
+        annotations_key: Optional[str] = None,
+        min_annotations: int = 1,
+        on_missing: str = "skip",
+        additional_keys: List[Tuple] = None) -> pd.DataFrame:
+    """
+    Apply `parse_annotation` to a local file or a file stored in s3
+    in jsonlines format, and return a dataframe of labels. Can also
+    pass additional keys/key paths to extract from the source data
+    and add as columns on the dataframe. The final key in each tuple
+    in `additional_keys` will be used as the column name for those
+    values in the returned dataframe.
+
+    See `parse_annotation` for more information about enforcing
+    `min_annotations` requirements.
+
+    Parameters
+    ==========
+    filepath: str or pathlib.Path
+        Path to a local file or an s3 storage location (prefixed by
+        's3://'), in jsonlines format
+    project_key: str
+        The key that contains the dict of annotation data
+    label_key: str
+        The key that contains the final labeled value to extract,
+        in the object (dict) indexed by `project_key`.
+    annotations_key: str
+        If applicable, the key in the record that contains the list of
+        individual worker annotations (as dict records). Only used if
+        `min_annotations` > 1.
+    min_annotations: int
+        Number of annotations required for a valid label. If > 1, checks
+        the length of the annotation records in
+        `record[label_key][annotations_key]`, which should be a list.
+    on_missing: str
+        One of "error", or "skip" (default="skip"). The function's
+        behavior if a record is encountered that does not meet the
+        `min_annotations` threshold (annotations are missing).
+        Only used if `min_annotations` > 1.
+        If "skip", function will return `None` for invalid records and
+        log a warning. If "error", will raise a ValueError instead.
+    additional_keys: list or List[list]
+        List of tuples identifying sequential keys to access a value
+        in the annotation record json using
+        croissant.utils.nested_get_item. If the key is top-level, pass
+        it as a 1-tuple.
+    """
+    if str(filepath).startswith("s3://"):
+        data = s3_get_object(filepath)["Body"].read()
+        annotations = read_jsonlines(data)
+    else:
+        annotations = read_jsonlines(filepath)
+    parser = partial(parse_annotation, project_key=project_key,
+                     label_key=label_key, annotations_key=annotations_key,
+                     min_annotations=min_annotations, on_missing=on_missing)
+    labels = {label_key: list(map(parser, annotations))}
+    if additional_keys:
+        getters = []
+        # Get all keys so only traverse data once for all additional keys
+        for keypath in additional_keys:
+            labels.update({keypath[-1]: []})
+            getters.append((keypath[-1], partial(nested_get_item,
+                                                 key_list=keypath)))
+        for annotation in annotations:
+            for getter in getters:
+                labels[getter[0]].append(getter[1](annotation))
+    return pd.DataFrame(labels)
+
+
+def parse_annotation(record: dict,
+                     project_key: str,
+                     label_key: str,
+                     annotations_key: Optional[str] = None,
+                     min_annotations: int = 1,
+                     on_missing: str = "skip") -> Any:
+    """
+    Parses an annotation record and returns the label value (from the
+    `record[project_key][label_key]` key).
+    Optionally enforces a requirement of `min_annotations` number of
+    annotations. The format of the output manifest depends heavily on
+    the post-annotation lambda functions. This assumes, minimally,
+    that there is a dict of annotation data indexed by `project_key`.
+    In this dict there is a key `label_key` that stores the value for
+    the final label of this record.
+
+    Parameters
+    ==========
+    record: dict
+        A single record from output.manifest (output of SageMaker GT
+        labeling job)
+    project_key: str
+        The key that contains the dict of annotation data
+    label_key: str
+        The key that contains the final labeled value to extract,
+        in the object (dict) indexed by `project_key`.
+    annotations_key: str
+        If applicable, the key in the record that contains the list of
+        individual worker annotations (as dict records). Only used if
+        `min_annotations` > 1.
+    min_annotations: int
+        Number of annotations required for a valid label. If > 1, checks
+        the length of the annotation records in
+        `record[label_key][annotations_key]`, which should be a list.
+    on_missing: str
+        One of "error", or "skip" (default="skip"). The function's
+        behavior if a record is encountered that does not meet the
+        `min_annotations` threshold (annotations are missing).
+        Only used if `min_annotations` > 1.
+        If "skip", function will return `None` for invalid records and
+        log a warning. If "error", will raise a ValueError instead.
+
+    Returns
+    =======
+    The data stored in `record[project_key][label_key]`. This can be
+    any json-serializable value.
+
+    Raises
+    ======
+    ValueError if `on_missing="error"` and a record does not meet the
+    number of `min_annotations` to be valid.
+    """
+    label = record[project_key][label_key]
+    if min_annotations > 1:
+        annotations = len(record[project_key][annotations_key])
+        if annotations < min_annotations:
+            if on_missing == "error":
+                raise ValueError(
+                    "Not enough annotations for this record. Minimum number "
+                    f"of required annotations: {min_annotations} (got "
+                    f"{annotations}). \n Full Record: \n {record}")
+            else:
+                return None
+    return label

--- a/croissant/utils.py
+++ b/croissant/utils.py
@@ -1,26 +1,9 @@
 """Miscellaneous utility functions that don't quite belong elsewhere."""
-from typing import Any, Union, BinaryIO
+from typing import Any
 from functools import reduce
 import operator
-from pathlib import Path
-import json
 import boto3
 from urllib.parse import urlparse
-
-
-def read_jsonlines(f: Union[Path, BinaryIO]) -> list:
-    """
-    Parse a jsonlines file from path, bytes, or from file-object (bytes)
-    and load as a list of json objects
-    """
-    if isinstance(f, (str, Path)):
-        with open(f, "r") as f_:
-            data = f_.readlines()
-    elif isinstance(f, bytes):
-        data = f.splitlines()
-    else:
-        data = f.readlines()
-    return list(map(json.loads, data))
 
 
 def nested_get_item(obj: dict, key_list: list) -> Any:
@@ -40,8 +23,6 @@ def nested_get_item(obj: dict, key_list: list) -> Any:
     key_list: list
         List of keys, in order, to traverse through the nested dict
         and return a value.
-    value: Optional[Any]
-        Default value to return. Defaults to None.
     Raises
     ======
     KeyError if any key from `key_list` is not present in `obj`

--- a/croissant/utils.py
+++ b/croissant/utils.py
@@ -1,0 +1,77 @@
+"""Miscellaneous utility functions that don't quite belong elsewhere."""
+from typing import Any, Union, BinaryIO
+from functools import reduce
+import operator
+from pathlib import Path
+import json
+import boto3
+from urllib.parse import urlparse
+
+
+def read_jsonlines(f: Union[Path, BinaryIO]) -> list:
+    """
+    Parse a jsonlines file from path, bytes, or from file-object (bytes)
+    and load as a list of json objects
+    """
+    if isinstance(f, (str, Path)):
+        with open(f, "r") as f_:
+            data = f_.readlines()
+    elif isinstance(f, bytes):
+        data = f.splitlines()
+    else:
+        data = f.readlines()
+    return list(map(json.loads, data))
+
+
+def nested_get_item(obj: dict, key_list: list) -> Any:
+    """
+    Get item from a list of keys, which define nested paths.
+
+    Example:
+    ```
+    d = {"a": {"b": {"c": 1}}}
+    keys = ["a", "b", "c"]
+    nested_get_item(d, keys)    # 1
+    ```
+    Parameters
+    ==========
+    obj: dict
+        The dictionary to retrieve items by key
+    key_list: list
+        List of keys, in order, to traverse through the nested dict
+        and return a value.
+    value: Optional[Any]
+        Default value to return. Defaults to None.
+    Raises
+    ======
+    KeyError if any key from `key_list` is not present in `obj`
+    """
+    # Handle single key just in case, since a string is also an iterator
+    if isinstance(key_list, str):
+        key_list = [key_list]
+    else:
+        key_list = list(key_list)
+    if len(key_list) == 0:
+        raise ValueError("Empty list is not a valid key.")
+    return reduce(operator.getitem, key_list, obj)
+
+
+def s3_get_object(uri: str) -> dict:
+    """
+    Utility wrapper for calling get_object from the boto3 s3 client,
+    using an s3 URI directly (rather than having to parse the bucket
+    and key)
+    Parameters
+    ==========
+    uri: str
+        Location of the s3 file object
+    Returns
+    =======
+    Dict containing response from boto3 s3 client
+    """
+    s3 = boto3.client("s3")
+    parsed_s3 = urlparse(uri)
+    bucket = parsed_s3.netloc
+    file_key = parsed_s3.path[1:]
+    response = s3.get_object(Bucket=bucket, Key=file_key)
+    return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy
 scipy
 boto3
 moto
+jsonlines

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scipy
 boto3
 moto
 jsonlines
+s3fs

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pandas>=1.0.0
 scikit-learn>=0.23.1
 numpy
 scipy
+boto3
+moto

--- a/test/test_ingest.py
+++ b/test/test_ingest.py
@@ -1,0 +1,115 @@
+import pytest
+import pandas as pd
+
+from croissant.ingest import parse_annotation, annotation_df_from_file
+
+
+record_no_worker = {
+    "experiment-id": 000,
+    "roi-id": 111,
+    "source-ref": "s3://bucket/input.png",
+    "another-source-ref": "s3://bucket/input_1.png",
+    "project": {
+        "sourceData": "s3://bucket/input.png",
+        "label": 0,
+    },
+    "2-line-2-project-metadata": {
+        "type": "groundtruth/custom",
+        "job-name": "cool-job",
+        "human-annotated": "yes",
+        "creation-date": "2020-06-11T00:54:41.833000"
+    }
+}
+
+record_3_worker = {
+    "experiment-id": 867,
+    "roi-id": 5309,
+    "source-ref": "s3://bucket/input.png",
+    "another-source-ref": "s3://bucket/input_1.png",
+    "project": {
+        "sourceData": "s3://bucket/input.png",
+        "label": "not cell",
+        "workerAnnotations": [
+            {
+                "workerId": "private.us-west-2.aa",
+                "roiLabel": "not cell"
+            },
+            {
+                "workerId": "private.us-west-2.bb",
+                "roiLabel": "cell"
+            },
+            {
+                "workerId": "private.us-west-2.cc",
+                "roiLabel": "not cell"
+            }
+        ]
+    },
+    "2-line-2-project-metadata": {
+        "type": "groundtruth/custom",
+        "job-name": "cool-job",
+        "human-annotated": "yes",
+        "creation-date": "2020-06-11T00:54:41.833000"
+    }
+}
+
+
+@pytest.mark.parametrize(
+    "record", [record_3_worker],
+)
+def test_raises_error_on_missing(record):
+    with pytest.raises(ValueError):
+        parse_annotation(record, "project", "label", "workerAnnotations",
+                         min_annotations=4, on_missing="error")
+
+
+@pytest.mark.parametrize(
+    "record, min_annotations, annotations_key, expected",
+    [
+        (record_3_worker, 3, "workerAnnotations", "not cell",),
+        (record_3_worker, 1, "workerAnnotations", "not cell", ),
+        (record_no_worker, 1, None, 0,),
+    ]
+)
+def test_parse_annotation(record, min_annotations,
+                          annotations_key, expected):
+    # Mocking s3_get_object and the read method from the response
+    label = parse_annotation(record, "project", "label",
+                             annotations_key=annotations_key,
+                             min_annotations=min_annotations,
+                             on_missing="skip")
+    assert label == expected
+
+
+@pytest.mark.parametrize(
+    "records, additional_keys, expected",
+    [
+        (
+            [record_no_worker, record_3_worker],
+            [("roi-id",), ("2-line-2-project-metadata", "job-name",)],
+            pd.DataFrame({"roi-id": [111, 5309],
+                          "job-name": ["cool-job", "cool-job"],
+                          "label": [0, "not cell"]})
+        ),
+        (
+            [record_no_worker, record_3_worker],
+            None,
+            pd.DataFrame({"label": [0, "not cell"]})
+        ),
+        (
+            [record_no_worker, record_3_worker],
+            [],
+            pd.DataFrame({"label": [0, "not cell"]})
+        )
+    ]
+)
+def test_annotation_df_from_file(monkeypatch, tmp_path, records,
+                                 additional_keys, expected):
+    """Testing additional keys behavior, file loading and parser
+    already unit tested.
+    """
+    monkeypatch.setattr("croissant.ingest.read_jsonlines", lambda x: x)
+    actual = annotation_df_from_file(
+        records, "project", "label",
+        annotations_key=None, min_annotations=1, on_missing="skip",
+        additional_keys=additional_keys)
+    pd.testing.assert_frame_equal(actual, expected, check_like=True)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,98 @@
+import pytest
+import boto3
+from moto import mock_s3
+from botocore.exceptions import ClientError
+
+from croissant.utils import nested_get_item, read_jsonlines, s3_get_object
+
+
+@pytest.mark.parametrize(
+    "d, keys, expected",
+    [
+        ({"a": {1: {"c": "a"}}}, ["a", 1], {"c": "a"},),
+        ({"a": {1: {"c": "a"}}}, ["a", 1, "c"], "a",),
+        ({"a": "b"}, ["a"], "b",),
+        ({"a": "b"}, "a", "b",),
+    ]
+)
+def test_nested_get_item(d, keys, expected):
+    assert expected == nested_get_item(d, keys)
+
+
+@pytest.mark.parametrize(
+    "d, keys",
+    [
+        ({"a": {1: {"c": "a"}}}, ["b", 2],),
+        ({"a": {1: {"c": "a"}}}, ["a", 1, "s"],),
+        ({"a": "b"}, ["s"],),
+        ({"a": "b"}, "s",),
+        ({}, "a"),
+    ]
+)
+def test_nested_get_item_fails_if_missing_key(d, keys):
+    with pytest.raises(KeyError):
+        nested_get_item(d, keys)
+
+
+@pytest.mark.parametrize(
+    "d, keys",
+    [
+        ({"a": 1}, [],),
+        ({}, [],),
+    ]
+)
+def test_nested_get_item_fails_with_empty_list(d, keys):
+    with pytest.raises(ValueError):
+        nested_get_item(d, keys)
+
+
+@pytest.mark.parametrize(
+    "file_type", ["path", "binaryio", "bytes"]
+)
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (b'{"a": 123, "b": "ijk"}\n{"a": 999, "b": "lop"}',
+         [{"a": 123, "b": "ijk"}, {"a": 999, "b": "lop"}],),
+        (b'{"a": 123, "b": "ijk"}', [{"a": 123, "b": "ijk"}],),
+        (b'', []),
+    ]
+)
+def test_read_jsonlines(tmp_path, file_type, data, expected):
+    if file_type == "bytes":
+        assert expected == read_jsonlines(data)
+    else:
+        with open(tmp_path / "filename", "wb") as f:
+            f.write(data)
+        if file_type == "path":
+            assert expected == read_jsonlines(tmp_path / "filename")
+        else:
+            with open(tmp_path / "filename", "r") as f:
+                assert expected == read_jsonlines(f)
+
+
+@mock_s3
+def test_s3_get_object():
+    # Set up the fake bucket and object
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket="mybucket")
+    body = b'{"a": 1}\n{"b": 2}'
+    s3.put_object(Bucket="mybucket", Key="my/file.json",
+                  Body=body)
+    # Run the test
+    response = s3_get_object("s3://mybucket/my/file.json")
+    assert body == response["Body"].read()
+
+
+@mock_s3
+def test_s3_fails_not_exist():
+    # Set up the fake bucket and object
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket="mybucket")
+    body = b'{"a": 1}\n{"b": 2}'
+    s3.put_object(Bucket="mybucket", Key="my/file.json",
+                  Body=body)
+    # Run the test
+    with pytest.raises(ClientError) as e:
+        s3_get_object("s3://mybucket/my/nonexistentfile.json")
+        assert e.response["Error"]["Code"] == "NoSuchKey"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,7 +3,7 @@ import boto3
 from moto import mock_s3
 from botocore.exceptions import ClientError
 
-from croissant.utils import nested_get_item, read_jsonlines, s3_get_object
+from croissant.utils import nested_get_item, s3_get_object
 
 
 @pytest.mark.parametrize(
@@ -44,31 +44,6 @@ def test_nested_get_item_fails_if_missing_key(d, keys):
 def test_nested_get_item_fails_with_empty_list(d, keys):
     with pytest.raises(ValueError):
         nested_get_item(d, keys)
-
-
-@pytest.mark.parametrize(
-    "file_type", ["path", "binaryio", "bytes"]
-)
-@pytest.mark.parametrize(
-    "data, expected",
-    [
-        (b'{"a": 123, "b": "ijk"}\n{"a": 999, "b": "lop"}',
-         [{"a": 123, "b": "ijk"}, {"a": 999, "b": "lop"}],),
-        (b'{"a": 123, "b": "ijk"}', [{"a": 123, "b": "ijk"}],),
-        (b'', []),
-    ]
-)
-def test_read_jsonlines(tmp_path, file_type, data, expected):
-    if file_type == "bytes":
-        assert expected == read_jsonlines(data)
-    else:
-        with open(tmp_path / "filename", "wb") as f:
-            f.write(data)
-        if file_type == "path":
-            assert expected == read_jsonlines(tmp_path / "filename")
-        else:
-            with open(tmp_path / "filename", "r") as f:
-                assert expected == read_jsonlines(f)
 
 
 @mock_s3


### PR DESCRIPTION
Methods to retrieve output of SageMaker GT from s3. Designed to fit our data, but should be flexible enough for the content of most output manifests from SageMaker GT.

The primary entry is `annotation_df_from_file`. This will produce a dataframe of labels, optionally with more values from the output manifest records (from `additional_keys`), such as "roi-id" for joining with data in the database. We can use this function directly on a file stored in s3, or a local file, to produce the dataframe of labels. 

I added the (optional) validation steps in `parse_annotation` because I noticed that the incomplete output manifest (from the latest chained job) had labels for ROIs that had only been annotated 2 or fewer times. I'm not sure if the final completed manifest will have 3 annotations for all ROIs, or if chaining the job broke the requirement for 3 annotators... We can find out once it's complete with this function.

Below are examples of using the ingest functions on our real data (uri = "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-prod-v2-output/2-line-2-project-prod-v2-chain/manifests/output/output.manifest"). 

We need to create a separate story for actually ingesting and combining all the data, since the data set is not complete.

## Examples
----------------------
### Full module runner
Command:
```
python -m croissant.ingest "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-prod-v2-output/2-line-2-project-prod-v2-chain/manifests/output/output.manifest" s3://kat-mlflow-test.alleninstitute.org/ingest/test-ingest.csv 2-line-2-project majorityLabel --min_annotations 3 --on_missing skip --roi_id_key roi-id --annotations_key 2-line-2-project,workerAnnotations --drop_na
```

Result:
URI: s3://kat-mlflow-test.alleninstitute.org/ingest/test-ingest.csv ([download link](https://s3-us-west-2.amazonaws.com/kat-mlflow-test.alleninstitute.org/ingest/test-ingest.csv))
Sample data:
<img width="239" alt="Screen Shot 2020-06-26 at 2 05 39 PM" src="https://user-images.githubusercontent.com/34227334/85901229-27ed1080-b7b6-11ea-834a-6402bf9c4a5e.png">

### Functions
**Typical case**: pulling the data and grabbing additional fields. Also demonstrates mapping "cell" and "not cell" labels to integers.

![Screen Shot 2020-06-26 at 12 03 48 PM](https://user-images.githubusercontent.com/34227334/85892575-0ab04600-b7a6-11ea-86f3-a4466f4a33d4.png)

**Additional case**: enforcing minimum annotator requirements. First: using "skip" for `on_missing` results in null values for the label:

![Screen Shot 2020-06-26 at 12 08 54 PM](https://user-images.githubusercontent.com/34227334/85892600-14d24480-b7a6-11ea-8bea-b7205c7ab66a.png)

Can drop the null values for a clean dataset:

![Screen Shot 2020-06-26 at 12 09 09 PM](https://user-images.githubusercontent.com/34227334/85892656-2d425f00-b7a6-11ea-9a64-b592a8b09bab.png)