### PR TITLE
Exclude punctuation in mlflow db secret

### DIFF
--- a/deploy/cloudformation/mlflow-db-template.yml
+++ b/deploy/cloudformation/mlflow-db-template.yml
@@ -293,7 +293,7 @@ Resources:
         SecretStringTemplate: '{"username": "mlflow"}'
         GenerateStringKey: "password"
         PasswordLength: 20
-        ExcludeCharacters: '"@/\'
+        ExcludePunctuation: true
       Tags:
         -
           Key: AppName


### PR DESCRIPTION
Some punctuation in the database password was causing an invalid SQLAlchemy string when trying to connect to the DB. Just use only alphanumeric.