### PR TITLE
MLFlow Experiment Cloud Requirements

### DIFF
--- a/deploy/cloudformation/mlflow-db-template.yml
+++ b/deploy/cloudformation/mlflow-db-template.yml
@@ -109,6 +109,11 @@ Resources:
         - Key: Network
           Value: VPN Connected Subnet
 
+  ArtifactBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "${StackType}.croissant-artifacts.alleninstitute.org"
+
   VpcSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/deploy/cloudformation/mlflow-db-template.yml
+++ b/deploy/cloudformation/mlflow-db-template.yml
@@ -114,6 +114,13 @@ Resources:
     Properties:
       BucketName: !Sub "${StackType}.croissant-artifacts.alleninstitute.org"
 
+  VpcUserSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub "${AWS::StackName}-users-vpce-sg"
+      GroupDescription: Security group to add individual IPs for access to instances
+      VpcId: !Ref Vpc
+
   VpcSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -124,25 +131,36 @@ Resources:
         - IpProtocol: udp
           FromPort: !Ref ClientVpnPort
           ToPort: !Ref ClientVpnPort
-          CidrIp: !Ref SecurityGroupCIDR
+          SourceSecurityGroupId: !Ref VpcUserSecurityGroup
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: !Ref SecurityGroupCIDR
-        - IpProtocol: tcp
-          FromPort: 5432
-          ToPort: 5432      # For Postgres DB
-          CidrIp: !Ref SecurityGroupCIDR
+          SourceSecurityGroupId: !Ref VpcUserSecurityGroup
       SecurityGroupEgress:
         - IpProtocol: udp
           FromPort: !Ref ClientVpnPort
           ToPort: !Ref ClientVpnPort
           CidrIp: !Ref SecurityGroupCIDR
-        - IpProtocol: tcp
-          FromPort: 5432
-          ToPort: 5432      # For Postgres DB
-          CidrIp: !Ref SecurityGroupCIDR
-
+    
+  PostgresVpcSecurityIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Access postgres ports (ingress)
+      GroupId: !Ref VpcSecurityGroup
+      SourceSecurityGroupId: !Ref VpcSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+  
+  PostgresVpcSecurityEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      Description: Access postgres ports (egress)
+      GroupId: !Ref VpcSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      CidrIp: !Ref SecurityGroupCIDR
 
   VpcInternetGateway:
     Type: AWS::EC2::InternetGateway
@@ -215,6 +233,7 @@ Resources:
         Description: VPN to access VPC Resources for MLFlow
         SecurityGroupIds:
           - !Ref VpcSecurityGroup
+          - !Ref VpcUserSecurityGroup
         ServerCertificateArn: !Ref ServerCertificateArn
         SplitTunnel: true
         VpcId: !Ref Vpc

--- a/deploy/cloudformation/mlflow-db-template.yml
+++ b/deploy/cloudformation/mlflow-db-template.yml
@@ -36,10 +36,10 @@ Parameters:
     Default: 443
     Description: Port for client VPN
   
-  SecurityGroupCIDR:
+  SecurityGroupOutboundCIDR:
     Type: String
     Default: 0.0.0.0/0
-    Description: CIDR IP to be granted access by the security group; use 0.0.0.0/0 to accept all IPs
+    Description: CIDR IP to be granted outbound access by the security group; use 0.0.0.0/0 to be open to the internet
   
   VpcCIDR:
     Type: String
@@ -59,7 +59,7 @@ Parameters:
   SubnetCIDRs:
     Type: CommaDelimitedList 
     Default: 10.0.10.0/24,10.0.11.0/24
-    Description: CIDR blocks for subsets. Can't overlap with local CIDR of VPC or VPN assignment.
+    Description: CIDR blocks for subnets. Can't overlap with local CIDR of VPC or VPN assignment.
 
 Resources:
 
@@ -136,11 +136,25 @@ Resources:
           FromPort: 22
           ToPort: 22
           SourceSecurityGroupId: !Ref VpcUserSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          Description: Access postgres ports within VPC (ingress) subnet 0
+          CidrIp: !Select
+          - 0
+          - !Ref SubnetCIDRs
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          Description: Access postgres ports within VPC (ingress) subnet 1
+          CidrIp: !Select
+          - 1
+          - !Ref SubnetCIDRs
       SecurityGroupEgress:
         - IpProtocol: udp
           FromPort: !Ref ClientVpnPort
           ToPort: !Ref ClientVpnPort
-          CidrIp: !Ref SecurityGroupCIDR
+          CidrIp: !Ref SecurityGroupOutboundCIDR
     
   PostgresVpcSecurityIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -160,7 +174,17 @@ Resources:
       IpProtocol: tcp
       FromPort: 5432
       ToPort: 5432
-      CidrIp: !Ref SecurityGroupCIDR
+      CidrIp: !Ref SecurityGroupOutboundCIDR
+
+  PostgresVpcSecurityEgressDestinationGroup:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      Description: Access postgres ports (egress) within same SG
+      GroupId: !Ref VpcSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      DestinationSecurityGroupId: !Ref VpcSecurityGroup
 
   VpcInternetGateway:
     Type: AWS::EC2::InternetGateway

--- a/deploy/mlflow/mlflow.Dockerfile
+++ b/deploy/mlflow/mlflow.Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.8.0
 
 RUN pip install \
     mlflow>=1.8.0 \
+    boto3 \
     psycopg2-binary
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
Resolves #17 and #31 

## Changes
* Updated the prod CloudFormation Stack to create the artifact bucket:  [s3://prod.croissant-artifacts.alleninstitute.org/](https://console.aws.amazon.com/s3/buckets/prod.croissant-artifacts.alleninstitute.org/?region=us-west-2)
* Created an experiment for the upcoming data `prod_2l2p`.
* Tightened up the requirements for access so that the ports aren't open to the internet
* Added boto3 to the docker install for mlflow ui so that it can download artifacts from s3

### Testing
Checked experiment propagated to the database:
MLFlow UI
![Screen Shot 2020-07-07 at 12 00 13 PM](https://user-images.githubusercontent.com/34227334/86829803-b466c100-c049-11ea-9599-37dbc9034729.png)

Data API Query:
```
select * from experiments;
```
Returned:

|experiment_id|name     |artifact_location                                    |lifecycle_stage|
|-------------|---------|-----------------------------------------------------|---------------|
|0            |Default  |./mlruns/0                                           |active         |
|1            |prod_2l2p|s3://prod.croissant-artifacts.alleninstitute.org/2l2p|active         |


Update: Resolves #31 
Updated the stack with the tighter security groups. Made an ec2 instance and was able to connect to the serverless db.
![Screen Shot 2020-07-21 at 3 38 07 PM](https://user-images.githubusercontent.com/34227334/88114472-c6c41d00-cb68-11ea-9c0d-28194c2c4005.png)


