### PR TITLE
Feature/merge sgt outputs

### DIFF
--- a/test/test_ingest.py
+++ b/test/test_ingest.py
@@ -1,13 +1,10 @@
 import pytest
 import pandas as pd
-from moto import mock_s3
-import boto3
 import jsonlines
 import numpy as np
 
 from croissant.ingest import (
-    parse_annotation, annotation_df_from_file, _read_jsonlines,
-    _ingest_uri, _keypath)
+    parse_annotation, annotation_df_from_file, _ingest_uri, _keypath)
 
 
 def generate_record(experiment_id, roi_id, label, annotation_labels=None):
@@ -93,54 +90,13 @@ def test_annotation_df_from_file(monkeypatch, tmp_path, records,
     """Testing additional keys behavior, file loading and parser
     already unit tested.
     """
-    monkeypatch.setattr("croissant.ingest._read_jsonlines",
+    monkeypatch.setattr("croissant.ingest.read_jsonlines",
                         lambda x: jsonlines.Reader(records, loads=lambda y: y))
     actual = annotation_df_from_file(
         records, "project", "label",
         annotations_key=None, min_annotations=1, on_missing="skip",
         additional_keys=additional_keys)
     pd.testing.assert_frame_equal(actual, expected, check_like=True)
-
-
-@pytest.mark.parametrize(
-    "body, expected",
-    [
-        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
-        (b'{"a": 1}', [{"a": 1}]),
-        (b'', []),
-    ]
-)
-def test_read_jsonlines_file(tmp_path, body, expected):
-    with open(tmp_path / "filename", "wb") as f:
-        f.write(body)
-    reader = _read_jsonlines(tmp_path / "filename")
-    response = []
-    for record in reader:
-        response.append(record)
-    reader.close()
-    assert expected == response
-
-
-@mock_s3
-@pytest.mark.parametrize(
-    "body, expected",
-    [
-        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
-        (b'{"a": 1}', [{"a": 1}]),
-        (b'', []),
-    ]
-)
-def test_read_jsonlines_s3(body, expected):
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="mybucket")
-    s3.put_object(Bucket="mybucket", Key="my/file.json",
-                  Body=body)
-    reader = _read_jsonlines("s3://mybucket/my/file.json")
-    response = []
-    for record in reader:
-        response.append(record)
-    reader.close()
-    assert expected == response
 
 
 @pytest.mark.parametrize(
@@ -188,7 +144,7 @@ def test_ingest_uri(monkeypatch, roi_id_key, annotations_key, min_annotations,
         generate_record(123, 456, "cell", ["cell", "not cell", "cell"]),
         generate_record(999, 888, "not cell",
                         ["not cell", "not cell", "not cell", "not cell"])]
-    monkeypatch.setattr("croissant.ingest._read_jsonlines",
+    monkeypatch.setattr("croissant.ingest.read_jsonlines",
                         lambda x: jsonlines.Reader(records, loads=lambda y: y))
     actual = _ingest_uri(
         records, "project", "label", roi_id_key, annotations_key,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,7 +3,8 @@ import boto3
 from moto import mock_s3
 from botocore.exceptions import ClientError
 
-from croissant.utils import nested_get_item, s3_get_object
+from croissant.utils import (nested_get_item, s3_get_object,
+                             read_jsonlines)
 
 
 @pytest.mark.parametrize(
@@ -71,3 +72,42 @@ def test_s3_fails_not_exist():
     with pytest.raises(ClientError) as e:
         s3_get_object("s3://mybucket/my/nonexistentfile.json")
         assert e.response["Error"]["Code"] == "NoSuchKey"
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
+        (b'{"a": 1}', [{"a": 1}]),
+        (b'', []),
+    ]
+)
+def test_read_jsonlines_file(tmp_path, body, expected):
+    with open(tmp_path / "filename", "wb") as f:
+        f.write(body)
+    reader = read_jsonlines(tmp_path / "filename")
+    response = []
+    for record in reader:
+        response.append(record)
+    assert expected == response
+
+
+@mock_s3
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
+        (b'{"a": 1}', [{"a": 1}]),
+        (b'', []),
+    ]
+)
+def test_read_jsonlines_s3(body, expected):
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket="mybucket")
+    s3.put_object(Bucket="mybucket", Key="my/file.json",
+                  Body=body)
+    reader = read_jsonlines("s3://mybucket/my/file.json")
+    response = []
+    for record in reader:
+        response.append(record)
+    assert expected == response


### PR DESCRIPTION
### Overview
Adds utility functions to merge multiple SagemakerGroundTruth output manifests into 1 manifest. This does not have a CLI, as it is expected to be used during data-science mode to prepare some classifier inputs. An example of doing that is provided in this description. This is the machinery for #25, and this PR demonstrates that it is ready as soon as the annotators are done.

### Validation
The following call retrieves 2 output manifests from S3 and merges them (the code in this PR) and then talks to on-prem databases to assemble the training data (not part of this PR, not part of this repo). The code for this file is included here, collapsed, as a starting point example for the next dev starting to cook up a jupyter notebook or something.
<details>
  <summary>example_merge_and_prepare.py</summary>

```python
import logging
import json
from sklearn.model_selection import train_test_split

import croissant.merge_utils as mu
from slapp.utils import query_utils
from slapp.rois import ROI

logging.getLogger().setLevel(logging.INFO)


def meta_from_experiment_id(experiment_id, db_connection):
    meta_data = db_connection.query(
        "SELECT e.name AS rig, i.depth, st.acronym AS targeted_structure, "
        "d.full_genotype FROM ophys_experiments oe "
        "JOIN ophys_sessions os ON oe.ophys_session_id=os.id "
        "JOIN equipment e ON e.id=os.equipment_id "
        "JOIN specimens sp ON sp.id=os.specimen_id "
        "JOIN imaging_depths i ON i.id=oe.imaging_depth_id "
        "JOIN structures st ON st.id=oe.targeted_structure_id "
        "JOIN donors d ON d.id=sp.donor_id "
        f"WHERE oe.id = {experiment_id}")

    if len(meta_data) != 1:
        raise ValueError(f"expected 1 record for {experiment_id}, "
                         f"found {len(meta_data)}")

    return meta_data[0]


# merge some output manifests together
src_uris = [
        "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-prod-v2-output/2-line-2-project-prod-v2/manifests/output/output.manifest",
        "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-output/2-line-2-project-prod/manifests/output/output.manifest"]

dst_uri = "/home/danielk/sgt_merged_manifest.jsonl"

_ = mu.merge_outputs(src_uris, dst_uri)

# select only the valid ones
x = list(mu.read_jsonlines(dst_uri))
valid = [i for i in x if i['merged-project']['majorityLabel'] is not None]

# retrieve the data necessary for input to
label_credentials = query_utils.get_db_credentials(
        env_prefix="LABELING_",
        **query_utils.label_defaults)
label_connection = query_utils.DbConnection(**label_credentials)
lims_credentials = query_utils.get_db_credentials(
        env_prefix="LIMS_",
        **query_utils.lims_defaults)
lims_connection = query_utils.DbConnection(**lims_credentials)

rois = []
data = []
translator = {'cell': 1, 'not cell': 0}
for record in valid:
    roi = ROI.roi_from_query(record['roi-id'], label_connection)
    meta = meta_from_experiment_id(record['experiment-id'], lims_connection)
    entry = {
            "roi_id": roi.roi_id,
            "coo_cols": roi._sparse_coo.col.tolist(),
            "coo_rows": roi._sparse_coo.row.tolist(),
            "coo_data": roi._sparse_coo.data.tolist(),
            "image_shape": roi.image_shape,
            "trace": roi.trace
            }
    entry.update(meta)
    entry.update(
            {"label": translator[record['merged-project']['majorityLabel']]})
    data.append(entry)

train, test = train_test_split(data, test_size=0.3, random_state=0)

training_path = "/home/danielk/mlflow_example/training_data.json"
with open(training_path, "w") as f:
    json.dump(train, f)
testing_path = "/home/danielk/mlflow_example/testing_data.json"
with open(testing_path, "w") as f:
    json.dump(test, f)
print(f"wrote {training_path}")
print(f"wrote {testing_path}")

```  

</details>

```
~/croissant$ python example_merge_and_prepare.py
WARNING:root:skipped some records {
  "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-prod-v2-output/2-line-2-project-prod-v2/manifests/output/output.manifest": 392,
  "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-output/2-line-2-project-prod/manifests/output/output.manifest": 765
}
INFO:root:n records used: {
  "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-prod-v2-output/2-line-2-project-prod-v2/manifests/output/output.manifest": 608,
  "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-output/2-line-2-project-prod/manifests/output/output.manifest": 235
}
INFO:root:wrote /home/danielk/sgt_merged_manifest.jsonl with 694 records and 198 valid majorities.
wrote /home/danielk/mlflow_example/training_data.json
wrote /home/danielk/mlflow_example/testing_data.json
```
The inputs for training have now been created. 
Then, following the [automated mlflow CLI test](https://github.com/AllenInstitute/croissant/blob/01f580bfb80a411f47bf285ff29b0620548b2dcb/.circleci/config.yml#L57-L71) as an example.
```
export MLFLOW_TRACKING_URI=/home/danielk/mlflow_example/tracking
export ARTIFACT_URI=/home/danielk/mlflow_example/artifacts
export MYEXPERIMENT=my_experiment
mlflow experiments create \
              --experiment-name ${MYEXPERIMENT} \
              --artifact-location ${ARTIFACT_URI}
```
```
~/croissant$ mlflow run . --backend local --experiment-name ${MYEXPERIMENT} -P training_data=/home/danielk/mlflow_example/training_data.json -P test_data=/home/danielk/mlflow_example/testing_data.json -P scoring="['roc_auc']" -P refit=roc_auc -P log_level=INFO

2020/07/09 15:57:59 INFO mlflow.projects: === Created directory /tmp/tmps19ei_lc for downloading remote URIs passed to arguments of type 'path' ===
2020/07/09 15:57:59 INFO mlflow.projects: === Running command 'source /home/danielk/miniconda3/bin/../etc/profile.d/conda.sh && conda activate mlflow-ead6525c1aa4af043de9afdf421d4abe083b57fe 1>&2 && python -m croissant.train --training_data /home/danielk/mlflow_example/training_data.json --test_data /home/danielk/mlflow_example/testing_data.json --scoring '['"'"'roc_auc'"'"']' --refit roc_auc --log_level INFO' in run with ID '5f5b74552cea4e08b626012146bb1ad3' === 
INFO:TrainClassifier:Reading training data and extracting features.
INFO:TrainClassifier:Fitting model to data!
INFO:TrainClassifier:fitting model with **<snipped>**
**<snipped convergence warnings>**
INFO:ClassifierTrainer:Model fit, with best score 0.6386397707231041 and best parameters {'model__l1_ratio': 0.25}.
/home/danielk/miniconda3/envs/mlflow-ead6525c1aa4af043de9afdf421d4abe083b57fe/lib/python3.8/site-packages/joblib/numpy_pickle.py:103: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
  pickler.file_handle.write(chunk.tostring('C'))
INFO:ClassifierTrainer:logged training to mlflow run 5f5b74552cea4e08b626012146bb1ad3
2020/07/09 15:58:05 INFO mlflow.projects: === Run (ID '5f5b74552cea4e08b626012146bb1ad3') succeeded ===

```
which has written a model:
```
$ ls /home/danielk/mlflow_example/artifacts/5f5b74552cea4e08b626012146bb1ad3/artifacts/
trained_model.joblib
```
and we can also confirm this through the mlflow ui:
```
$ mlflow ui --backend-store-uri /home/danielk/mlflow_example/tracking
```
![image](https://user-images.githubusercontent.com/32312979/87100236-b626b500-c200-11ea-8f48-47b71ba8d526.png)
