### PR TITLE
makes read_jsonlines a generator and moves to utils

### DIFF
--- a/croissant/utils.py
+++ b/croissant/utils.py
@@ -12,6 +12,17 @@ def read_jsonlines(uri: Union[str, Path]) -> Generator[dict, None, None]:
     """
     Generator to load jsonlines file from either s3 or a local
     file, given a uri (s3 uri or local filepath).
+
+    Parameters
+    ----------
+    uri: str or Path
+        source file in jsonlines format
+
+    Yields
+    ------
+    record: dict
+        a single entry from the file
+
     """
     if str(uri).startswith("s3://"):
         data = s3_get_object(uri)["Body"].iter_lines(chunk_size=8192)    # The lines can be big        # noqa

--- a/test/test_ingest.py
+++ b/test/test_ingest.py
@@ -1,13 +1,10 @@
 import pytest
 import pandas as pd
-from moto import mock_s3
-import boto3
 import jsonlines
 import numpy as np
 
 from croissant.ingest import (
-    parse_annotation, annotation_df_from_file, _read_jsonlines,
-    _ingest_uri, _keypath)
+    parse_annotation, annotation_df_from_file, _ingest_uri, _keypath)
 
 
 def generate_record(experiment_id, roi_id, label, annotation_labels=None):
@@ -93,54 +90,13 @@ def test_annotation_df_from_file(monkeypatch, tmp_path, records,
     """Testing additional keys behavior, file loading and parser
     already unit tested.
     """
-    monkeypatch.setattr("croissant.ingest._read_jsonlines",
+    monkeypatch.setattr("croissant.ingest.read_jsonlines",
                         lambda x: jsonlines.Reader(records, loads=lambda y: y))
     actual = annotation_df_from_file(
         records, "project", "label",
         annotations_key=None, min_annotations=1, on_missing="skip",
         additional_keys=additional_keys)
     pd.testing.assert_frame_equal(actual, expected, check_like=True)
-
-
-@pytest.mark.parametrize(
-    "body, expected",
-    [
-        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
-        (b'{"a": 1}', [{"a": 1}]),
-        (b'', []),
-    ]
-)
-def test_read_jsonlines_file(tmp_path, body, expected):
-    with open(tmp_path / "filename", "wb") as f:
-        f.write(body)
-    reader = _read_jsonlines(tmp_path / "filename")
-    response = []
-    for record in reader:
-        response.append(record)
-    reader.close()
-    assert expected == response
-
-
-@mock_s3
-@pytest.mark.parametrize(
-    "body, expected",
-    [
-        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
-        (b'{"a": 1}', [{"a": 1}]),
-        (b'', []),
-    ]
-)
-def test_read_jsonlines_s3(body, expected):
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="mybucket")
-    s3.put_object(Bucket="mybucket", Key="my/file.json",
-                  Body=body)
-    reader = _read_jsonlines("s3://mybucket/my/file.json")
-    response = []
-    for record in reader:
-        response.append(record)
-    reader.close()
-    assert expected == response
 
 
 @pytest.mark.parametrize(
@@ -188,7 +144,7 @@ def test_ingest_uri(monkeypatch, roi_id_key, annotations_key, min_annotations,
         generate_record(123, 456, "cell", ["cell", "not cell", "cell"]),
         generate_record(999, 888, "not cell",
                         ["not cell", "not cell", "not cell", "not cell"])]
-    monkeypatch.setattr("croissant.ingest._read_jsonlines",
+    monkeypatch.setattr("croissant.ingest.read_jsonlines",
                         lambda x: jsonlines.Reader(records, loads=lambda y: y))
     actual = _ingest_uri(
         records, "project", "label", roi_id_key, annotations_key,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,7 +3,8 @@ import boto3
 from moto import mock_s3
 from botocore.exceptions import ClientError
 
-from croissant.utils import nested_get_item, s3_get_object
+from croissant.utils import (nested_get_item, s3_get_object,
+                             read_jsonlines)
 
 
 @pytest.mark.parametrize(
@@ -71,3 +72,42 @@ def test_s3_fails_not_exist():
     with pytest.raises(ClientError) as e:
         s3_get_object("s3://mybucket/my/nonexistentfile.json")
         assert e.response["Error"]["Code"] == "NoSuchKey"
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
+        (b'{"a": 1}', [{"a": 1}]),
+        (b'', []),
+    ]
+)
+def test_read_jsonlines_file(tmp_path, body, expected):
+    with open(tmp_path / "filename", "wb") as f:
+        f.write(body)
+    reader = read_jsonlines(tmp_path / "filename")
+    response = []
+    for record in reader:
+        response.append(record)
+    assert expected == response
+
+
+@mock_s3
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
+        (b'{"a": 1}', [{"a": 1}]),
+        (b'', []),
+    ]
+)
+def test_read_jsonlines_s3(body, expected):
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket="mybucket")
+    s3.put_object(Bucket="mybucket", Key="my/file.json",
+                  Body=body)
+    reader = read_jsonlines("s3://mybucket/my/file.json")
+    response = []
+    for record in reader:
+        response.append(record)
+    assert expected == response


### PR DESCRIPTION
Turns `read_jsonlines` into a generator, moves to a non-private function in utils.
This PR is totally unnecessary, but I had already done it as part of copying some of this functionality to `slapp` for merging SGT output manifests.
I think the generator is nice, so I am making the PR anyway.