### PR TITLE
Tweaks/aws postgres mlflow tracking backend

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -6,6 +6,8 @@ dependencies:
   - pip
   - pip:
       - mlflow
+      - psycopg2-binary
+      - boto3
       - argschema==2.0.1
       - pandas>=1.0.0
       - scikit-learn>=0.23.1

--- a/croissant/train.py
+++ b/croissant/train.py
@@ -4,8 +4,7 @@ import logging
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import KFold, GridSearchCV
-from sklearn.metrics import (accuracy_score, confusion_matrix,
-                             classification_report)
+from sklearn.metrics import accuracy_score, confusion_matrix
 import mlflow
 import mlflow.sklearn
 import argschema
@@ -119,7 +118,7 @@ def mlflow_log_classifier(training_data_path: Path,
         with tempfile.TemporaryDirectory() as temp_dir:
             tmp_model_path = Path(temp_dir) / "trained_model.joblib"
             joblib.dump(clf.best_estimator_, tmp_model_path)
-            mlflow.log_artifact(tmp_model_path)
+            mlflow.log_artifact(str(tmp_model_path))
 
         # run the model on test_data
         with open(test_data_path, 'r') as fp:
@@ -132,10 +131,7 @@ def mlflow_log_classifier(training_data_path: Path,
         cmat = confusion_matrix(y_true, y_pred)
         for i in [0, 1]:
             for j in [0, 1]:
-                mlflow.log_metric(f"count_{i}_{j}", cmat[i, j])
-
-        mlflow.log_param('classification_report',
-                         classification_report(y_true, y_pred))
+                mlflow.log_metric(f"count_{i}_{j}", int(cmat[i, j]))
 
         run_id = mlrun.info.run_id
 

--- a/test/test_train.py
+++ b/test/test_train.py
@@ -138,8 +138,6 @@ def test_mlflow_log_classifier(tmp_path, mock_classifier,
 
     # check that this run has the right stuff
     myrun = client.get_run(run_id)
-    # params
-    assert 'classification_report' in myrun.data.params
     # metrics
     for k, v in mock_classifier.best_params_.items():
         assert k in myrun.data.metrics


### PR DESCRIPTION
previously, this was only tested with a local mlflow tracking backend. When trying it with the AWS-hosted postgres backend, found some necessary tweaks.
* the mlflow-generated conda env needed pyscopg2 and boto3
* postgres can't take np.int64
* log_artifact needs a str not a path
* classification report was too long for postgres. Ditched it.