### PR TITLE
Containerizes and sets up fargate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,15 @@ jobs:
               -P refit=roc_auc \
               -P log_level=INFO
 
+  docker:
+    machine: true
+    steps:
+      - checkout
+      - run: echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
+      - run: docker build --build-arg MYBRANCH=${CIRCLE_BRANCH} -t alleninstitutepika/croissant:${CIRCLE_SHA1} docker/
+      - run: docker run --entrypoint /bin/bash alleninstitutepika/croissant:${CIRCLE_SHA1} -c "conda run -n myenv pytest"
+      - run: docker push alleninstitutepika/croissant:${CIRCLE_SHA1}
+
 orbs:
   python: circleci/python@0.1
 version: 2.1
@@ -82,3 +91,12 @@ workflows:
           requires:
             - build
             - lint
+      - docker:
+          requires:
+            - build
+            - lint
+          filters:
+            branches:
+              only:
+                - master
+                - /.*docker.*/

--- a/MLproject
+++ b/MLproject
@@ -4,6 +4,4 @@ conda_env: conda.yaml
 
 entry_points:
   main:
-    parameters:
-      message: {type: str, default: "Hello World"}
     command: "python -m croissant.train"

--- a/croissant/online_training.py
+++ b/croissant/online_training.py
@@ -1,0 +1,146 @@
+import boto3
+import os
+import argschema
+import marshmallow as mm
+import json
+
+
+class OnlineTrainingException(Exception):
+    pass
+
+
+class OnlineTrainingSchema(argschema.ArgSchema):
+    cluster = argschema.fields.Str(
+        required=False,
+        default=None,
+        missing=None,
+        allow_none=True,
+        description=("The cluster name. If not provided will attempt to get "
+                     "environment variable ONLINE_TRAINING_CLUSTER. See boto3 "
+                     "docs for run_task arg `cluster`"))
+    taskDefinition = argschema.fields.Str(
+        required=True,
+        default=None,
+        allow_none=True,
+        description=("The task definition name. If not provided will attempt "
+                     "to get from environment variable ONLINE_TRAINING_TASK. "
+                     "See boto3 docs for run_task arg `taskDefinition`"))
+    container = argschema.fields.Str(
+        required=True,
+        default=None,
+        allow_none=True,
+        description=("The container name. If not provided will attempt "
+                     "to get from environment variable "
+                     "ONLINE_TRAINING_CONTAINER. See boto3 docs for "
+                     "run_task arg `taskDefinition`"))
+    subnet = argschema.fields.Str(
+        required=True,
+        default=None,
+        allow_none=True,
+        description=("The subnet. If not provided, will attempt to get from "
+                     "environment variable ONLINE_TRAINING_SUBNET. See boto3 "
+                     "docs for run_task arg `subnets` under "
+                     "`network_configuration`)"))
+    securityGroup = argschema.fields.Str(
+        required=True,
+        default=None,
+        allow_none=True,
+        description=("The security group. If not provided, will attempt to "
+                     "get from environment variable ONLINE_TRAINING_SECURITY. "
+                     "See boto3 docs for run_task arg `securityGroups` under "
+                     "`network_configuration`)"))
+    trackingURI = argschema.fields.Str(
+        required=True,
+        default=None,
+        allow_none=True,
+        description=("mlflow tracking URI. If not provided, will attempt to "
+                     "get environment variable MLFLOW_TRACKING_URI."))
+    training_args = argschema.fields.Str(
+        required=True,
+        description=("(as string) dict with keys and values to pass to the "
+                     "container-hosted croissant training module. Will be "
+                     "parsed inside the container against "
+                     "`croissant.train.TrainingSchema`. Proper CLI quote "
+                     "formatting: --training_args '{\"arg1\": \"val1\", }'"))
+    experiment_name = argschema.fields.Str(
+        required=True,
+        default=None,
+        allow_none=True,
+        description=("name of mlflow experiment. If not provided, will "
+                     "attempt to get environment variable MLFLOW_EXPERIMENT. "
+                     "It is assumed that this experiment was previously "
+                     "created with an s3 artifact URI. If not, a new "
+                     "experiment will be created, but the artifact will be "
+                     "local to the container and lost at job completion."))
+
+    @mm.post_load
+    def env_populate(self, data, **kwargs):
+        lookup = {
+                "cluster": "ONLINE_TRAINING_CLUSTER",
+                "taskDefinition": "ONLINE_TRAINING_TASK",
+                "container": "ONLINE_TRAINING_CONTAINER",
+                "subnet": "ONLINE_TRAINING_SUBNET",
+                "securityGroup": "ONLINE_TRAINING_SECURITY",
+                "trackingURI": "MLFLOW_TRACKING_URI",
+                "experiment_name": "MLFLOW_EXPERIMENT"}
+        for k, v in lookup.items():
+            if data[k] is None:
+                if v not in os.environ.keys():
+                    raise OnlineTrainingException(
+                            f"{k} was not specified and {v} is not an "
+                            "ENV variable")
+                data[k] = os.environ.get(v)
+        return data
+
+
+class OnlineTrainingOutputSchema(argschema.schemas.DefaultSchema):
+    response = argschema.fields.Dict(
+        required=True,
+        description="boto3 response to run_task call")
+
+
+class OnlineTraining(argschema.ArgSchemaParser):
+    default_schema = OnlineTrainingSchema
+    default_output_schema = OnlineTrainingOutputSchema
+
+    def run(self):
+        client = boto3.client('ecs')
+        # we don't have databricks or kubernetes set up
+        # mlflow will always run with local backend
+        command = ["--backend", "local", "--experiment-name",
+                   self.args['experiment_name']]
+        # format the training args so mlflow passes them through to the module
+        for k, v in json.loads(self.args['training_args']).items():
+            command.append("-P")
+            command.append(f"{k}={v}")
+
+        response = client.run_task(
+            cluster=self.args['cluster'],
+            launchType="FARGATE",
+            taskDefinition=self.args['taskDefinition'],
+            networkConfiguration={
+                "awsvpcConfiguration": {
+                    "subnets": [self.args['subnet']],
+                    "securityGroups": [self.args['securityGroup']],
+                    "assignPublicIp": "ENABLED"}},
+            overrides={
+                "containerOverrides": [
+                    {
+                        "name": self.args['container'],
+                        "command": command,
+                        "environment": [
+                            {
+                                "name": "MLFLOW_TRACKING_URI",
+                                "value": self.args['trackingURI']}]
+                            }
+                    ]
+                }
+            )
+
+        # the response has some datetime objects, we can force those to str
+        self.output({'response': response}, default=str, indent=2)
+
+
+if __name__ == "__main__":  # pragma nocover
+    online = OnlineTraining()
+    online.run()

--- a/croissant/online_training.py
+++ b/croissant/online_training.py
@@ -17,14 +17,16 @@ class OnlineTrainingSchema(argschema.ArgSchema):
         allow_none=True,
         description=("The cluster name. If not provided will attempt to get "
                      "environment variable ONLINE_TRAINING_CLUSTER. See boto3 "
-                     "docs for run_task arg `cluster`"))
+                     "docs for run_task arg `cluster` "
+                     "`https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task`"))  # noqa
     taskDefinition = argschema.fields.Str(
         required=True,
         default=None,
         allow_none=True,
         description=("The task definition name. If not provided will attempt "
                      "to get from environment variable ONLINE_TRAINING_TASK. "
-                     "See boto3 docs for run_task arg `taskDefinition`"))
+                     "See boto3 docs for run_task arg `taskDefinition` "
+                     "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task"))  # noqa
     container = argschema.fields.Str(
         required=True,
         default=None,
@@ -32,7 +34,8 @@ class OnlineTrainingSchema(argschema.ArgSchema):
         description=("The container name. If not provided will attempt "
                      "to get from environment variable "
                      "ONLINE_TRAINING_CONTAINER. See boto3 docs for "
-                     "run_task arg `taskDefinition`"))
+                     "run_task arg `overrides` "
+                     "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task"))  # noqa
     subnet = argschema.fields.Str(
         required=True,
         default=None,
@@ -40,7 +43,8 @@ class OnlineTrainingSchema(argschema.ArgSchema):
         description=("The subnet. If not provided, will attempt to get from "
                      "environment variable ONLINE_TRAINING_SUBNET. See boto3 "
                      "docs for run_task arg `subnets` under "
-                     "`network_configuration`)"))
+                     "`network_configuration` "
+                     "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task"))  # noqa
     securityGroup = argschema.fields.Str(
         required=True,
         default=None,
@@ -48,13 +52,15 @@ class OnlineTrainingSchema(argschema.ArgSchema):
         description=("The security group. If not provided, will attempt to "
                      "get from environment variable ONLINE_TRAINING_SECURITY. "
                      "See boto3 docs for run_task arg `securityGroups` under "
-                     "`network_configuration`)"))
+                     "`network_configuration` "
+                     "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task"))  # noqa
     trackingURI = argschema.fields.Str(
         required=True,
         default=None,
         allow_none=True,
         description=("mlflow tracking URI. If not provided, will attempt to "
-                     "get environment variable MLFLOW_TRACKING_URI."))
+                     "get environment variable MLFLOW_TRACKING_URI. See:"
+                     "https://mlflow.org/docs/latest/cli.html#cmdoption-mlflow-run-b"))  # noqa
     training_args = argschema.fields.Str(
         required=True,
         description=("(as string) dict with keys and values to pass to the "

--- a/croissant/online_training_helper.py
+++ b/croissant/online_training_helper.py
@@ -1,0 +1,94 @@
+import argschema
+import boto3
+from botocore.exceptions import NoCredentialsError
+import json
+import logging
+import mlflow
+import multiprocessing
+
+
+class EnvHelperException(Exception):
+    pass
+
+
+class EnvHelperSchema(argschema.ArgSchema):
+    stack = argschema.fields.Str(
+        required=True,
+        description="stack name from which to suggest environment variables")
+    timeout = argschema.fields.Float(
+        required=False,
+        default=20.0,
+        description=("timeout for mlflow tracking client list_experiments "
+                     "call. Without a VPN connection, this call hangs."))
+
+
+def mlflow_experiment_check(tracking_uri):
+    client = mlflow.tracking.MlflowClient(tracking_uri=tracking_uri)
+    experiments = client.list_experiments()
+    exoptions = ""
+    for e in experiments:
+        if e.artifact_location.startswith("s3://"):
+            exoptions += (f"\nexport MLFLOW_EXPERIMENT={e.name}")
+    return exoptions
+
+
+class EnvHelper(argschema.ArgSchemaParser):
+    default_schema = EnvHelperSchema
+
+    def run(self):
+        client = boto3.client('cloudformation')
+        try:
+            desc = client.describe_stacks(StackName=self.args['stack'])
+        except NoCredentialsError as e:
+            logging.error(str(e))
+            logging.error("no AWS credentials found.")
+            return
+
+        if len(desc['Stacks']) != 1:
+            raise EnvHelperException(f"description for {self.args['stack']} "
+                                     "did not return exactly one entry")
+        outs = {i['OutputKey']: i['OutputValue']
+                for i in desc['Stacks'][0]['Outputs']}
+
+        exports = ""
+        lookup = {
+                'ONLINE_TRAINING_CLUSTER': outs['FargateClusterName'],
+                'ONLINE_TRAINING_TASK': outs['TaskDefinitionName'],
+                'ONLINE_TRAINING_CONTAINER': outs['ContainerNameOutput'],
+                'ONLINE_TRAINING_SUBNET': outs['PrivateSubnet'],
+                'ONLINE_TRAINING_SECURITY': outs['VPCUserSecurityGroupId']}
+        sets = [f"{k}={v}" for k, v in lookup.items()]
+        exports = [f"export {s}" for s in sets]
+
+        client = boto3.client('secretsmanager')
+        secret = json.loads(
+                client.get_secret_value(
+                    SecretId=outs['DBSecret'])['SecretString'])
+        tracking = (f"{secret['engine']}://{secret['username']}:"
+                    f"{secret['password']}@{secret['host']}:{secret['port']}/"
+                    f"{secret['dbname']}")
+        tracking = tracking.replace("postgres", "postgresql")
+        exports.append("export MLFLOW_TRACKING_URI=" + tracking)
+        exports = "\n".join(exports)
+        logger = logging.getLogger()
+        logger.setLevel(logging.INFO)
+        logger.info(f"ENV variables to use stack {self.args['stack']}"
+                    f"\n\n{exports}\n")
+
+        # this call hangs without a VPN connection, so give it a timeout
+        pool = multiprocessing.Pool(processes=1)
+        result = pool.apply_async(mlflow_experiment_check, (tracking,))
+        try:
+            exoptions = result.get(timeout=self.args['timeout'])
+        except multiprocessing.context.TimeoutError:
+            logging.warning("check for mlflow experiments timed out after "
+                            f"{self.args['timeout']} seconds. Perhaps you are "
+                            "not connected to the client VPN.")
+        else:
+            logger.info("Available experiments with s3 artifact stores:"
+                        f"\n{exoptions}")
+
+
+if __name__ == "__main__":
+    eh = EnvHelper()
+    eh.run()

--- a/deploy/cloudformation/mlflow-db-template.yml
+++ b/deploy/cloudformation/mlflow-db-template.yml
@@ -65,6 +65,12 @@ Parameters:
     Default: 10.0.10.0/24,10.0.11.0/24
     Description: CIDR blocks for subnets. Can't overlap with local CIDR of VPC or VPN assignment.
 
+  ContainerName:
+    Type: String
+    Default: croissant-container
+    Description: Name of container for fargate usage
+
+
 Resources:
 
   Vpc:
@@ -409,8 +415,7 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Image: !Ref ImageUri
-          Name: !Sub "${AWS::StackName}-container-task"
-          Name: croissant-container
+          Name: !Ref ContainerName
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -431,6 +436,18 @@ Outputs:
   VPCId:
     Description: VPCId of the newly created VPC
     Value: !Ref Vpc
+  VPCUserSecurityGroupId:
+    Description: VPCId of the user security group
+    Value: !Ref VpcUserSecurityGroup
+  FargateClusterName:
+    Description: name of fargate cluster
+    Value: !Ref Cluster
+  TaskDefinitionName:
+    Description: name of ECS task for fargate deployment
+    Value: !Ref ContainerTask
+  ContainerNameOutput:
+    Description: name of container in fargate deployment
+    Value: !Ref ContainerName
   PrivateSubnet:
     Description: SubnetId of the VPN connected subnet
     Value: !Ref PrivateSubnet

--- a/deploy/cloudformation/mlflow-db-template.yml
+++ b/deploy/cloudformation/mlflow-db-template.yml
@@ -15,6 +15,10 @@
 
 Parameters:
 
+  ImageUri:
+    Type: String
+    Description: ECS tasks should pull this docker image
+
   StackType:
     Type: String
     Description: What is the role of this stack
@@ -353,6 +357,75 @@ Resources:
       SecretId: !Ref DBSecret
       TargetId: !Ref ServerlessAuroraDb
       TargetType: AWS::RDS::DBCluster
+
+  EcsLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "${AWS::StackName}-ecs"
+      RetentionInDays: 60
+
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub "${AWS::StackName}-fargate-cluster"
+
+  ContainerExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - "ecs-tasks.amazonaws.com"
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: ContainerBucketReadWrite
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:GetObject"
+                  - "s3:PutObject"
+                Resource:
+                  - "arn:aws:s3:::prod.slapp.alleninstitute.org/*"
+                  - "arn:aws:s3:::prod.croissant-artifacts.alleninstitute.org/*"
+        - PolicyName: ContainerExecutionPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ecr:GetAuthorizationToken"
+                  - "ecr:BatchCheckLayerAvailability"
+                  - "ecr:GetDownloadUrlForLayer"
+                  - "ecr:BatchGetImage"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: "*"
+
+  ContainerTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Image: !Ref ImageUri
+          Name: !Sub "${AWS::StackName}-container-task"
+          Name: croissant-container
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Sub "${AWS::StackName}-ecs"
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: croissant-container
+
+      Cpu: 4096
+      ExecutionRoleArn: !GetAtt ContainerExecutionRole.Arn
+      TaskRoleArn: !GetAtt ContainerExecutionRole.Arn
+      Family: container-task
+      Memory: 16384
+      RequiresCompatibilities:
+        - FARGATE
+      NetworkMode: awsvpc
 
 Outputs:
   VPCId:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM continuumio/miniconda3
+
+ARG MYBRANCH
+
+RUN git clone https://github.com/AllenInstitute/croissant
+
+# establish requirements at container build time
+# install croissant for CI/CD testing of container
+RUN cd croissant && \
+    git checkout ${MYBRANCH} && \
+    conda env create -f conda.yaml -n myenv && \
+    conda run -n myenv pip install .
+
+RUN conda clean -ayv && \
+    find /opt/conda -follow -type f -regextype posix-extended -regex '.*\.(pyc)' -delete
+
+WORKDIR /croissant
+ENTRYPOINT ["conda", "run", "-n", "myenv", "mlflow", "run", "--no-conda", "/croissant"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ boto3
 moto
 jsonlines
 s3fs
+psycopg2-binary

--- a/test/test_online_training.py
+++ b/test/test_online_training.py
@@ -13,9 +13,13 @@ def test_online_training_schema(tmp_path):
     os.environ["MLFLOW_EXPERIMENT"] = "abcdef98765"
 
     outj = tmp_path / "output.json"
+    training_args = {
+            "training_data": "some string",
+            "test_data": "some other string"
+            }
     args = {
             "output_json": str(outj),
-            "training_args": '{"arg1": "val1", "arg2": "val2"}',
+            "training_args": training_args,
             "cluster": "mycluster",
             "taskDefinition": "mycluster",
             "container": "mycontainer",
@@ -37,9 +41,13 @@ def test_online_training_schema_exception(tmp_path):
         tmp_env_var = os.environ.pop("MLFLOW_EXPERIMENT")
 
     outj = tmp_path / "output.json"
+    training_args = {
+            "training_data": "some string",
+            "test_data": "some other string"
+            }
     args = {
             "output_json": str(outj),
-            "training_args": '{"arg1": "val1", "arg2": "val2"}',
+            "training_args": training_args,
             "cluster": "mycluster",
             "taskDefinition": "mycluster",
             "container": "mycontainer",
@@ -56,9 +64,13 @@ def test_online_training_schema_exception(tmp_path):
 
 def test_online_training(tmp_path, monkeypatch):
     outj = tmp_path / "output.json"
+    training_args = {
+            "training_data": "some string",
+            "test_data": "some other string"
+            }
     args = {
             "output_json": str(outj),
-            "training_args": '{"arg1": "val1", "arg2": "val2"}',
+            "training_args": training_args,
             "cluster": "mycluster",
             "taskDefinition": "mycluster",
             "container": "mycontainer",

--- a/test/test_online_training.py
+++ b/test/test_online_training.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock
+import croissant.online_training as otr
+import json
+import pytest
+import os
+
+
+def test_online_training_schema(tmp_path):
+    tmp_env_var = None
+    if "MLFLOW_EXPERIMENT" in os.environ.keys():
+        tmp_env_var = os.environ.pop("MLFLOW_EXPERIMENT")
+
+    os.environ["MLFLOW_EXPERIMENT"] = "abcdef98765"
+
+    outj = tmp_path / "output.json"
+    args = {
+            "output_json": str(outj),
+            "training_args": '{"arg1": "val1", "arg2": "val2"}',
+            "cluster": "mycluster",
+            "taskDefinition": "mycluster",
+            "container": "mycontainer",
+            "subnet": "mysubnet",
+            "securityGroup": "mysecurity",
+            "trackingURI": "mytracking",
+            }
+    ot = otr.OnlineTraining(input_data=args, args=[])
+
+    assert ot.args["experiment_name"] == os.environ["MLFLOW_EXPERIMENT"]
+
+    if tmp_env_var is not None:
+        os.environ["MLFLOW_EXPERIMENT"] = tmp_env_var
+
+
+def test_online_training_schema_exception(tmp_path):
+    tmp_env_var = None
+    if "MLFLOW_EXPERIMENT" in os.environ.keys():
+        tmp_env_var = os.environ.pop("MLFLOW_EXPERIMENT")
+
+    outj = tmp_path / "output.json"
+    args = {
+            "output_json": str(outj),
+            "training_args": '{"arg1": "val1", "arg2": "val2"}',
+            "cluster": "mycluster",
+            "taskDefinition": "mycluster",
+            "container": "mycontainer",
+            "subnet": "mysubnet",
+            "securityGroup": "mysecurity",
+            "trackingURI": "mytracking",
+            }
+    with pytest.raises(otr.OnlineTrainingException):
+        otr.OnlineTraining(input_data=args, args=[])
+
+    if tmp_env_var is not None:
+        os.environ["MLFLOW_EXPERIMENT"] = tmp_env_var
+
+
+def test_online_training(tmp_path, monkeypatch):
+    outj = tmp_path / "output.json"
+    args = {
+            "output_json": str(outj),
+            "training_args": '{"arg1": "val1", "arg2": "val2"}',
+            "cluster": "mycluster",
+            "taskDefinition": "mycluster",
+            "container": "mycontainer",
+            "subnet": "mysubnet",
+            "securityGroup": "mysecurity",
+            "trackingURI": "mytracking",
+            "experiment_name": "myexperiment"
+            }
+
+    mock_boto = MagicMock()
+    mock_client = MagicMock()
+    mock_boto.client = MagicMock(return_value=mock_client)
+    mock_client.run_task = MagicMock(return_value={"a": "1", "b": "2"})
+    monkeypatch.setattr(target=otr, name="boto3", value=mock_boto)
+    ot = otr.OnlineTraining(input_data=args, args=[])
+    ot.run()
+
+    with open(outj, 'r') as f:
+        output = json.load(f)
+
+    assert output == {'response': mock_client.run_task.return_value}

--- a/test/test_train.py
+++ b/test/test_train.py
@@ -10,11 +10,6 @@ import croissant.train as train
 from croissant.features import FeatureExtractor
 import os
 import numpy as np
-from moto import mock_s3
-import boto3
-import argschema
-from urllib.parse import urlparse
-import marshmallow as mm
 
 
 @pytest.fixture()
@@ -201,33 +196,3 @@ def test_ClassifierTrainer(train_data, test_data, tmp_path, monkeypatch):
             args['training_data'],
             args['test_data'],
             mock_classifier)
-
-
-@mock_s3
-def test_TrainingSchema():
-    test_uri = "s3://myschematest/my/file.json"
-    train_uri = "s3://myschematest/my/file2.json"
-    test_up = urlparse(test_uri)
-    train_up = urlparse(train_uri)
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket=test_up.netloc)
-    s3.put_object(Bucket=test_up.netloc, Key=test_up.path[1:],
-                  Body=json.dumps({'a': 1}).encode('utf-8'))
-    s3.put_object(Bucket=test_up.netloc, Key=train_up.path[1:],
-                  Body=json.dumps({'a': 1}).encode('utf-8'))
-
-    args = {
-            "training_data": train_uri,
-            "test_data": test_uri
-            }
-
-    # uris exist, no errors
-    argschema.ArgSchemaParser(input_data=args,
-                              schema_type=train.TrainingSchema,
-                              args=[])
-
-    args["training_data"] = "s3://myschematest/does/not/exist.txt"
-    with pytest.raises(mm.ValidationError, match=r".*does not exist"):
-        argschema.ArgSchemaParser(input_data=args,
-                                  schema_type=train.TrainingSchema,
-                                  args=[])


### PR DESCRIPTION
### Dockerfile
* built by passing a `croissant` branch name to `docker build` run from the repo root dir.
```
docker build --build-arg MYBRANCH=<branch name> -t <name>:<tag> docker/
```
* has <branch name> installed inside a conda env.
* executes command by passing arguments to an `entrypoint` that invokes `mlflow run`.
* alternately, can run anything from the shell, for example, testing the repo inside the container, as shown in the circleci docker test:
```
docker run --entrypoint /bin/bash alleninstitutepika/croissant:${CIRCLE_SHA1} -c "conda run -n myenv pytest"
```

### Automated docker build and push
* docker image is built/tested/pushed on `master` branch or any branch containing `docker` in the name.
* docker step depends on `lint` and `build` passing, runs in parallel to `mlflow-cli` step
* docker image is tagged with the commit hash and pushed to docker hub https://hub.docker.com/repository/docker/alleninstitutepika/croissant

### Cloudformation
Adds these elements to the cloudformation stack:
* container, with ImageUri specified to `aws cloudformation create-stack` or `deploy`
* execution role and ECS task definition for the container
* cloudwatch log group for ECS (fargate) logging, to see what the container run stdout/stderr was.
* additional outputs to make life easier for figuring out args for calling fargate from client CLI.

Example call for creating a stack. This can take 5-10 minutes.
```
aws cloudformation create-stack \
    --stack-name mlflow-test-stack \
    --template-body <file URI to deploy/cloudformation/mlflow-db-template.yml> \
    --parameters \
        ParameterKey=StackType,ParameterValue=dev \ 
        ParameterKey=ServerCertificateArn,ParameterValue=arn:aws:acm:us-west-2:606907419058:certificate/953ac57b-ec7a-48c4-be34-d333aa3b1014 \ 
        ParameterKey=ClientCertificateArn,ParameterValue=arn:aws:acm:us-west-2:606907419058:certificate/6804b5ea-e853-45ec-8c97-33e7369f94c1 \
        ParameterKey=ImageUri,ParameterValue=docker.io/alleninstitutepika/croissant:6c9b667eac710c7aff1c7e39d6aeb89c7501e6d5 \
    --capabilities CAPABILITY_NAMED_IAM
```
The `deploy` command will update just the changeset, will be much faster, and will not destroy resources, or rename endpoints. For example, updating the `ImageUri` here:
```
aws cloudformation deploy \
  --template-file ./deploy/cloudformation/mlflow-db-template.yml \
  --stack-name mlflow-test-stack \
  --parameter-overrides ImageUri=docker.io/alleninstitutepika/croissant:da75ca5fdac9f7e857662fd48e0776ed3628dbeb \
  --capabilities CAPABILITY_NAMED_IAM
```

### Online Training Helper
Fargate/ECS needs to know what resources to use for a job. We can get those resource names by describing the cloudformation stack, getting a secret (made as part of the stack) and checking on mlflow experiments. The `online_training_helper` will do all of these things for you, and suggest (not set) some environment variables. For all of these suggestions to work, the user needs AWS credentials and a VPN connection to the VPC. The helper will let you know if you don't have these things. Only experiments with s3 artifact stores are suggested.
```
$ python -m croissant.online_training_helper --stack mlflow-test-stack
INFO:root:ENV variables to use stack mlflow-test-stack

export ONLINE_TRAINING_CLUSTER=mlflow-test-stack-fargate-cluster
export ONLINE_TRAINING_TASK=arn:aws:ecs:us-west-2:606907419058:task-definition/container-task:14
export ONLINE_TRAINING_CONTAINER=croissant-container
export ONLINE_TRAINING_SUBNET=<subnet Id>
export ONLINE_TRAINING_SECURITY=<security group Id>
export MLFLOW_TRACKING_URI=postgresql://<user>:<password>@<host>:<port>/<dbname>

INFO:alembic.runtime.migration:Context impl PostgresqlImpl.
INFO:alembic.runtime.migration:Will assume transactional DDL.
INFO:root:Available experiments with s3 artifact stores:

export MLFLOW_EXPERIMENT=example_aws_experiment
```
### Online Training
We want to be able to run containerized training from the client CLI. the `online_training` module uses `boto3` to accomplish this. Using `aws ecs run-task` or the [fargatecli](https://github.com/awslabs/fargatecli) is also possible. The boto3 wrapper here is more  succinct. Various required args can be set. If not set, the module will attempt to retrieve them from ENV variables. These have been suggested by the helper, or, the savvy user can set their own.
```
python -m croissant.online_training \
    --output_json ./output.json 
    --training_args '{"training_data": "s3://prod.slapp.alleninstitute.org/merged_2line_2project/training_data.json", "test_data": "s3://prod.slapp.alleninstitute.org/merged_2line_2project/testing_data.json"}'
```
Once launched, the status of the task can be tracked in the AWS console `ECS -> Cluster -> Tasks` where the cluster name is based on the cloudformation stack name. For example `mlflow-test-stack-fargate-cluster `. The logs of the job can be found from `Cloudwatch -> Logs -> LogGroups` and the log group will also be named based on the stack name, for example `mlflow-test-stack-ecs ` 

Portion of a cloudwatch log from a task run as described here:
![image](https://user-images.githubusercontent.com/32312979/89109495-6352ae80-d3f6-11ea-916d-3846d90ac862.png)

Successful mlflow entries from tasks run as described here:
![image](https://user-images.githubusercontent.com/32312979/89109516-a280ff80-d3f6-11ea-8211-6912f4892d25.png)
