### PR TITLE
pins mlflow

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.8
   - pip
   - pip:
-      - mlflow
+      - mlflow==1.10.0
       - psycopg2-binary
       - boto3
       - argschema==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy
 scipy
 argschema==2.0.1
 setuptools
-mlflow
+mlflow==1.10.0
 tables
 boto3
 moto


### PR DESCRIPTION
the mlflow version in an AWS stack postgres backend is set by the first `create_experiment` call. If a later user tries to add experiments with a different mlflow version, there is an error thrown.
while this PR does not prevent this from happening, it at least makes it explicit what version of mlflow we are trying to use.