### PR TITLE
Feature/support py377

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 jobs:
-  build:
-    executor: python/default
+  build38: &test-template
+    executor: 
+      name: python/default
+      tag: "3.8"
     steps:
       - checkout
       - python/load-cache
@@ -12,6 +14,12 @@ jobs:
             python -m pytest --cov croissant --cov-report xml
             bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
           name: Test
+
+  build377:
+    <<: *test-template
+    executor:
+      name: python/default
+      tag: "3.7.7"
 
   lint:
     executor: python/default
@@ -80,20 +88,23 @@ jobs:
       - run: docker push alleninstitutepika/croissant:${CIRCLE_SHA1}
 
 orbs:
-  python: circleci/python@0.1
+  python: circleci/python@0.3.2
 version: 2.1
 workflows:
   main:
     jobs:
-      - build
+      - build377
+      - build38
       - lint
       - mlflow-cli:
           requires:
-            - build
+            - build377
+            - build38
             - lint
       - docker:
           requires:
-            - build
+            - build377
+            - build38
             - lint
           filters:
             branches:

--- a/croissant/roi.py
+++ b/croissant/roi.py
@@ -1,5 +1,11 @@
 from __future__ import annotations  # noqa
-from typing import TypedDict, Optional, List, Tuple
+import sys
+from typing import Optional, List, Tuple
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 class Roi(TypedDict):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ moto
 jsonlines
 s3fs
 psycopg2-binary
+typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,11 @@ setup(
       packages=find_packages(),
       setup_requires=['setuptools_scm'],
       install_requires=required,
-      python_requires='>=3.8',
+      python_requires='>=3.7.7',
       classifiers=[
           "Development Status :: 3 - Alpha",
           "Intended Audience :: Science/Research",
+          "Programming Language :: Python :: 3.7.7"
           "Programming Language :: Python :: 3.8"
       ]
 )


### PR DESCRIPTION
### Background
We're packaging this repo up and distributing to pypi now, so that `ophys_etl_pipelines` can import it. That broke the [singularity build](https://app.circleci.com/pipelines/github/AllenInstitute/ophys_etl_pipelines/132/workflows/1c49de40-c57e-4060-be14-9476c373fdbe/jobs/257) (separate issue, this was hidden until merged to master). The reason is that the environment inside of the singularity container is based off of the Suite2P conda environment.yml which installs python 3.7.7. We install `ophys_etl_pipelines` on top of this suite2p environment. Our distribution of this repo did not allow install into a python 3.7.7 environment. It is not possible, or at least not trivial to update that environment to python 3.8. Thus, I think `croissant` should also support python 3.7.7.

### Changes
* Adds a circleCi build against python3.7.7
* Handles version-dependent `TypedDict` import
* updates `setup.py`