### PR TITLE
Add methods to select hyperparameters for LogisticRegression and RandomForestClassifier models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,7 @@ jobs:
               --experiment-name ${MYEXPERIMENT} \
               -P training_data=$PWD/test/resources/dev_train_rois.json \
               -P test_data=$PWD/test/resources/dev_test_rois.json \
-              -P scoring="['roc_auc']" \
-              -P refit=roc_auc \
-              -P log_level=INFO
+              -P max_iter=10
 
   docker:
     machine: true

--- a/conda.yaml
+++ b/conda.yaml
@@ -14,3 +14,5 @@ dependencies:
       - numpy
       - scipy
       - jsonlines
+      - hyperopt
+      - hpsklearn

--- a/croissant/train.py
+++ b/croissant/train.py
@@ -17,7 +17,7 @@ import pandas as pd
 from sklearn.pipeline import Pipeline
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
-from sklearn.model_selection import KFold, GridSearchCV, cross_val_score
+from sklearn.model_selection import KFold, cross_val_score
 from sklearn.metrics import confusion_matrix, get_scorer
 from sklearn.base import clone, BaseEstimator
 import sklearn

--- a/croissant/train.py
+++ b/croissant/train.py
@@ -511,7 +511,7 @@ def train_classifier(model: str,
 
 def mlflow_log_classifier(training_data_path: str,
                           test_data_path: str,
-                          clf: GridSearchCV,
+                          clf: Pipeline,
                           cv_scores: tuple,
                           metrics: Optional[dict] = None,
                           confusion_matrix: Optional[dict] = None,
@@ -528,8 +528,8 @@ def mlflow_log_classifier(training_data_path: str,
         Tuple of (<score name>, <scores per fold>) for optimization
         metric (training data). Encouraged by scikit-learn's model
         persistence page to ensure reproducibility.
-    clf: GridSeachCV
-        a trained classifier
+    clf: Pipeline
+        a Pipeline containing a trained classifier as the final step.
     metrics: dict
         Optional dictionary of {<score name>, <value>} for scored
         metrics on test data.
@@ -572,6 +572,9 @@ def mlflow_log_classifier(training_data_path: str,
         tmp_model_path = Path(temp_dir) / "trained_model.joblib"
         joblib.dump(clf, tmp_model_path)
         mlflow.log_artifact(str(tmp_model_path))
+
+    # log model parameters
+    mlflow.log_params(clf.steps[-1][1].get_params())
 
     # Log confusion matrix
     if confusion_matrix is not None:

--- a/croissant/train.py
+++ b/croissant/train.py
@@ -386,8 +386,9 @@ def _binary_confusion_dict(
         raise ValueError(
             "Must have binary labels for confusion matrix dictionary.")
     tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
-    return {f"{prefix}TN": tn, f"{prefix}FP": fp,
-            f"{prefix}FN": fn, f"{prefix}TP": tp}
+    # Casting to int to avoid numpy types (don't play nice with postgres)
+    return {f"{prefix}TN": int(tn), f"{prefix}FP": int(fp),
+            f"{prefix}FN": int(fn), f"{prefix}TP": int(tp)}
 
 
 def train_classifier(model: str,

--- a/croissant/train.py
+++ b/croissant/train.py
@@ -1,93 +1,488 @@
 from pathlib import Path
+import joblib
+import tempfile
 import logging
-from sklearn.linear_model import LogisticRegression
-from sklearn.model_selection import KFold, GridSearchCV
-from sklearn.metrics import accuracy_score, confusion_matrix
+import time
+from functools import partial
+from urllib.parse import urlparse
+from typing import Type, List, Optional, Callable, Union, Iterable
+
+import marshmallow as mm
+import numpy as np
 import mlflow
 import mlflow.sklearn
 import argschema
-import joblib
-import tempfile
-from typing import List
+import pandas as pd
+
+from sklearn.pipeline import Pipeline
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import KFold, GridSearchCV, cross_val_score
+from sklearn.metrics import confusion_matrix, get_scorer
+from sklearn.base import clone, BaseEstimator
+import sklearn
+
+from hyperopt import fmin, tpe, hp, Trials, STATUS_OK, space_eval
+from hpsklearn.components import _trees_hp_space
 
 from croissant.features import FeatureExtractor, feature_pipeline
-from croissant.utils import json_load_local_or_s3
+from croissant.utils import json_load_local_or_s3, object_exists
+
+logger = logging.getLogger("TrainClassifier")
 
 
-logger = logging.getLogger('TrainClassifier')
+class KFoldTuner(object):
+    """Tune a classifier with hyperopt on k-fold cross-validation.
+    This class contains the methods for easily tuning classifier
+    hyperparameters with an arbitrary pipeline. It will not tune the
+    parameters in the rest of the pipeline, only the final estimator
+    step (the classifier).
+
+    The hyperopt-sklearn library exists to make tuning sklearn models
+    with hyperopt, but currently they do not have enough preprocessing
+    methods implemented for us to use without changing our pipeline.
+    It may be useful to adopt it in the future.
+
+    This will work with any binary classifier that implements the
+    sklearn api (including xgboost for example). To create a tuner
+    with a default parameter space to search, subclass this class.
+    """
+    def __init__(
+            self, X: Iterable, y: Iterable,
+            classifier: Type[BaseEstimator], param_space: Iterable,
+            pipeline: Pipeline = None, n_splits: int = 5,
+            scorer: Union[str, Callable] = "roc_auc", seed: int = 42,
+            opt_algo: Callable = None):
+        """
+        Parameters
+        ----------
+        X: Iterable
+            Feature vector. Input data to train the model.
+        y: Iterable
+            True labels for the data to train the model.
+        classifier: Type[BaseEstimator]
+            A scikit-learn classifier class. Should be able to be
+            instantiated from params in the param space.
+        param_space: Iterable
+            The sampling space for parameter search. Should evaluate
+            to a pyll graph. See
+            http://hyperopt.github.io/hyperopt/getting-started/search_spaces/
+        pipeline: Pipeline
+            An optional Pipeline. Will use to preprocess data, and
+            append the classifier to the end of the Pipeline.
+            Will not search for hyperparameters to tune in the Pipeline.
+        n_splits: int, default=5
+            Number of k-folds to use for computing score. Default=5
+        scorer: str, Callable
+            A str (see sklearn model evaluation documentation) or a
+             scorer callable object / function with signature
+            scorer(estimator, X, y) which should return only a single
+            value.
+        seed: int, default=42
+            Random seed
+        opt_algo: Callable
+            Optimization algorithm to use. Either tpe.rand.suggest or
+            tpe.suggest. If not specified will default to tpe.suggest
+        """
+        self.param_space = param_space
+        self.X = X
+        self.y = y
+        self.classifier = classifier
+        self.pipeline = pipeline
+        self.kfolds = KFold(
+            n_splits=n_splits, random_state=seed, shuffle=True)
+        self.scorer = scorer
+        self.opt_algo = opt_algo or tpe.suggest
+        self.seed = seed
+        self.trials = Trials()
+
+    @staticmethod
+    def _objective(
+            params: dict = None, *, n_splits: int = 5,
+            classifier: Type[BaseEstimator] = None,
+            pipeline: Pipeline = None,
+            X: Iterable = None, y: Iterable = None,
+            scorer: Union[str, Callable] = None,
+            low_good: bool = True) -> dict:
+        """
+        Evaluate performance of a single model in a hyperopt trial.
+
+        Parameters
+        ----------
+        params: dict
+            Dictionary of parameters to be passed to the estimator.
+        n_splits: int, default=5
+            Number of k-folds to use for computing score. Default=5
+        classifier: Type[BaseEstimator]
+            A scikit-learn classifier class. Should be able to be
+            instantiated from **params.
+        pipeline: Pipeline
+            An optional Pipeline. Will use to preprocess data, and
+            append the classifier to the end of the Pipeline.
+        X: Iterable
+            Feature vector. Input data to train the model.
+        y: Iterable
+            True labels for the data to train the model.
+        scorer: str, Callable
+            A str (see sklearn model evaluation documentation) or a
+            scorer callable object / function with signature
+            scorer(estimator, X, y) which should return only a single
+            value.
+        low_good: bool
+            Whether a low score is better than a high score.
+
+        Returns
+        -------
+        Dictionary of results with the following keys:
+            loss: The model's average score using `scorer` over
+                  `nfolds` folds. If `low_good` is False, then return
+                  the negative of the score.
+            train_time_s: The time taken to train the model (seconds)
+            status: hyperopt status report; OK if successfully completed
+        """
+        # To add a new classifier to the end of the pipeline, need to clone
+        # existing pipeline; otherwise, classifiers will keep getting added
+        # on to the pipeline since pipeline `append` updates the reference.
+        start_time = time.time()
+        estimator = classifier(**params)
+        if pipeline is None:
+            new_pipe = Pipeline(steps=[("classifier", estimator)])
+        else:
+            new_pipe = clone(pipeline)
+            new_pipe.steps.append(("classifier", estimator))
+        loss = np.mean(
+            cross_val_score(new_pipe, X, y, scoring=scorer, cv=n_splits))
+        if not low_good:
+            # Hyperopt minimizes the optimization metric; if a high score is
+            # good, return the negative
+            loss = loss * -1
+        # Include additional metadata for `trials` object (useful for tracking)
+        result = {
+            "loss": loss,
+            "train_time_s": time.time() - start_time,
+            "status": STATUS_OK,
+            }
+        return result
+
+    def fmin(self, max_evals: int) -> dict:
+        """Optimization function. Minimizes the objective metric.
+
+        Parameters
+        ----------
+        max_evals: int
+            Maximum number of trials to evaluate when searching for
+            hyperparameters
+
+        Returns
+        -------
+        Dictionary of parameters that produced the best metric on
+        the objective function.
+        """
+        objective_fn = self._objective_fn(low_good=True)
+        best_set = fmin(
+            fn=objective_fn,
+            space=self.param_space,
+            algo=self.opt_algo,
+            trials=self.trials,
+            # Deprecated in numpy but required for hyperopt
+            rstate=np.random.RandomState(self.seed),
+            max_evals=max_evals
+        )
+        return space_eval(self.param_space, best_set)
+
+    def _objective_fn(self, low_good: bool) -> Callable:
+        """Build the objective function, using partial to 'fill in' the
+        required arguments so all it takes are the parameters from
+        hyperopt. Used for `fmin` and `fmax`.
+        """
+        objective_fn = partial(
+            self._objective,
+            n_splits=self.kfolds, classifier=self.classifier,
+            pipeline=self.pipeline, X=self.X, y=self.y, scorer=self.scorer,
+            low_good=low_good)
+        return objective_fn
+
+    def fmax(self, max_evals: int) -> dict:
+        """ Maximization version of fmin. Use when the scoring metric
+        should be maximized. Provided for convenience, since all
+        sklearn scorers follow the convention that higher return values
+        are better than lower return values. This way the user does not
+        need to remember to negate the score to use `fmin`.
+
+        Parameters
+        ----------
+        max_evals: int
+            Maximum number of trials to evaluate when searching for
+            hyperparameters
+
+        Returns
+        -------
+        Dictionary of parameters that produced the best metric on
+        the objective function.
+        """
+        objective_fn = self._objective_fn(low_good=False)
+        best_set = fmin(
+            fn=objective_fn,
+            space=self.param_space,
+            algo=self.opt_algo,
+            trials=self.trials,
+            # Deprecated in numpy but required for hyperopt
+            rstate=np.random.RandomState(self.seed),
+            max_evals=max_evals
+        )
+        return space_eval(self.param_space, best_set)
 
 
-class TrainingSchema(argschema.ArgSchema):
-    training_data = argschema.fields.Str(
-        required=True,
-        description=("s3 uri or local path, <stem>.json containing a list "
-                     "of dicts, where each dict can be passed into "
-                     "RoiWithMetaData.from_dict(). "
-                     "Note: not validated except as str to support this "
-                     "schema on remote clients."))
-    test_data = argschema.fields.Str(
-        required=True,
-        description=("s3 uri or local path, <stem>.json containing a list "
-                     "of dicts, where each dict can be passed into "
-                     "RoiWithMetaData.from_dict()."
-                     "Note: not validated except as str to support this "
-                     "schema on remote clients."))
-    scoring = argschema.fields.List(
-        argschema.fields.Str,
-        required=False,
-        cli_as_single_argument=True,
-        default=['roc_auc'],
-        description=("evaluated metrics for the model. See "
-                     "https://scikit-learn.org/stable/modules/model_evaluation.html#scoring-parameter"))  # noqa
-    refit = argschema.fields.Str(
-        required=False,
-        default='roc_auc',
-        description=("metric for refitting the model. See "
-                     "https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html"))  # noqa
+class RandomForestTuner(KFoldTuner):
+    """Special case of KFoldTuner with RandomForestClassifier and a
+    default parameter space option.
+    See KFoldTuner for more information."""
+    def __init__(self, X, y, pipeline, param_space=None, opt_algo=None,
+                 n_splits=5, scorer="roc_auc", seed=42, n_jobs=1):
+        """
+        Parameters
+        ----------
+        X: Iterable
+            Feature vector. Input data to train the model.
+        y: Iterable
+            True labels for the data to train the model.
+        classifier: Type[BaseEstimator]
+            A scikit-learn classifier class. Should be able to be
+            instantiated from params in the param space.
+        pipeline: Pipeline
+            An optional Pipeline. Will use to preprocess data, and
+            append the classifier to the end of the Pipeline.
+            Will not search for hyperparameters to tune in the Pipeline.
+        param_space: Iterable
+            The sampling space for parameter search. Should evaluate
+            to a pyll graph. See
+            http://hyperopt.github.io/hyperopt/getting-started/search_spaces/
+        n_splits: int, default=5
+            Number of k-folds to use for computing score. Default=5
+        scorer: str, Callable
+            A str (see sklearn model evaluation documentation) or a
+             scorer callable object / function with signature
+            scorer(estimator, X, y) which should return only a single
+            value.
+        seed: int, default=42
+            Random seed
+        opt_algo: Callable
+            Optimization algorithm to use. Either tpe.rand.suggest or
+            tpe.suggest. If not specified will default to tpe.suggest
+        """
+        # Chose not to use hyperopt-sklearn for the main classifier
+        # because of the limitations of preprocessing methods currently
+        # implemented. Going to utilize the defaults for now though.
+        default_space = _trees_hp_space(
+            lambda x: x,    # for the naming function; just use the param name
+            n_jobs=n_jobs,
+            random_state=seed)
+        space = param_space or default_space
+        super().__init__(
+            X, y, RandomForestClassifier, space, opt_algo=opt_algo,
+            pipeline=pipeline, n_splits=n_splits, scorer=scorer, seed=seed)
 
 
-def train_classifier(training_data_path: str, scoring: List[str],
-                     refit: str) -> GridSearchCV:
-    """Performs k-fold cross-validated grid search logistic regression
+class LogisticRegressionTuner(KFoldTuner):
+    """Special case of KFoldTuner with LogisticRegression and a
+        default parameter space option.
+        See KFoldTuner for more information."""
+    def __init__(self, X, y, pipeline, param_space=None, opt_algo=None,
+                 n_splits=5, scorer="roc_auc", seed=42, n_jobs=1):
+        """
+        Parameters
+        ----------
+        X: Iterable
+            Feature vector. Input data to train the model.
+        y: Iterable
+            True labels for the data to train the model.
+        classifier: Type[BaseEstimator]
+            A scikit-learn classifier class. Should be able to be
+            instantiated from params in the param space.
+        pipeline: Pipeline
+            An optional Pipeline. Will use to preprocess data, and
+            append the classifier to the end of the Pipeline.
+            Will not search for hyperparameters to tune in the Pipeline.
+        param_space: Iterable
+            The sampling space for parameter search. Should evaluate
+            to a pyll graph. See
+            http://hyperopt.github.io/hyperopt/getting-started/search_spaces/
+        n_splits: int, default=5
+            Number of k-folds to use for computing score. Default=5
+        scorer: str, Callable
+            A str (see sklearn model evaluation documentation) or a
+             scorer callable object / function with signature
+            scorer(estimator, X, y) which should return only a single
+            value.
+        seed: int, default=42
+            Random seed
+        opt_algo: Callable
+            Optimization algorithm to use. Either tpe.rand.suggest or
+            tpe.suggest. If not specified will default to tpe.suggest
+        """
+        default_space = {
+            "C": hp.choice("C", [100, 10, 1.0, 0.1, 0.01]),
+            "penalty": "elasticnet",
+            "solver": "saga",
+            "l1_ratio": hp.choice(
+                "l1_ratio", [0, 0, 0, 1, 1, 1, 0.5, 0.2, 0.8])
+            }
+        space = param_space or default_space
+        super().__init__(X, y, LogisticRegression, space, opt_algo=opt_algo,
+                         pipeline=pipeline, n_splits=n_splits, scorer=scorer,
+                         seed=seed)
+
+
+def _binary_confusion_dict(
+        y_true: Iterable, y_pred: Iterable, prefix: str = "") -> dict:
+    """
+    Helper function to unpack a confusion matrix from binary classifier
+    results. Useful for logging purposes as it's easier to consume
+    than an array.
 
     Parameters
     ----------
-    training_data_path: str
-        local path or s3 URI to training data in json format
-    scoring: List[str]
-        passed to GridSearchCV to specify tracked metrics
-    refit: str
-        passed to GridSearchCV to specify refit metric
+    y_true: Iterable
+        Iterable of true labels for data (binary)
+    y_pred: Iterable
+        Iterable of predicted labels from a classifier (binary)
+    prefix: Iterable, default=""
+        Prefix for the keys in the returned dictionary
 
     Returns
     -------
-    clf: GridSearchCV
-        the trained model
+    dict
+        Dictionary with the following keys (prefixed with `prefix`):
+            TN: true negative count
+            FP: false positive count
+            FN: false negative count
+            TP: true positive count
+    """
+    if len(set(y_true)) > 2:
+        raise ValueError(
+            "Must have binary labels for confusion matrix dictionary.")
+    tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
+    return {f"{prefix}TN": tn, f"{prefix}FP": fp,
+            f"{prefix}FN": fn, f"{prefix}TP": tp}
+
+
+def train_classifier(model: str,
+                     training_data_path: str,
+                     test_data_path: str,
+                     scorer: Union[str, Callable],
+                     max_iter: int,
+                     optimizer: str,
+                     test_metrics: Optional[List[str]] = None,
+                     n_folds: int = 5,
+                     seed: int = 42,
+                     refit: bool = True) -> Pipeline:
+    """Tunes and trains a model using hyperopt to optimize
+    hyperparameters. Internally uses k-fold cross validation to
+    compute optimization metrics. Uses `feature_pipeline` to
+    preprocess data. The trained and tuned classifier is appended
+    onto the pipeline as the final step.
+
+    Parameters
+    ----------
+    model: str
+        The model algorithm to use. One of "RandomForestClasifier"
+        or "LogisticRegression". See `TrainingSchema.MODEL_CHOICES`.
+    training_data_path: str
+        local path or s3 URI to training data in json format
+    test_data_path: str
+        local path or s3 URI to training data in json format
+    scorer: str or Callable
+        A str (see sklearn model evaluation documentation) or a
+        scorer callable object / function with signature
+        scorer(estimator, X, y) which should return only a single
+        value. Will optimize for this scorer.
+    max_iter: int
+        Maximum number of iterations to evaluate hyperparameters
+    optimizer: str
+        Optimizer to use. One of "rand" or "suggest". See
+        `TrainingSchema.OPTIMIZER_CHOICES`.
+    test_metrics: List of str (or Callable)
+        List of scorers to report metrics for model's performance on
+        the test data set. See `scorer`.
+    n_folds: int, default=5
+        Number of folds over which to compute training metrics during
+        hyperparameter optimization.
+    seed: int, default=42
+        Random seed
+    refit: bool, default=True
+        Whether to refit the model on the train and test set combined
+
+    Returns
+    -------
+    Pipeline
+        the trained model, in a Pipeline object
 
     """
-    logger.info('Reading training data and extracting features.')
+    logger.info("Reading training data and extracting features.")
     training_data = json_load_local_or_s3(training_data_path)
-
+    test_data = json_load_local_or_s3(test_data_path)
     features = FeatureExtractor.from_list_of_dict(training_data).run()
-    labels = [r['label'] for r in training_data]
+    test_features = FeatureExtractor.from_list_of_dict(test_data).run()
+    labels = [r["label"] for r in training_data]
+    test_labels = [r["label"] for r in test_data]
 
-    logger.info('Fitting model to data!')
+    # Instantiate model and (static) preprocessing pipeline
     pipeline = feature_pipeline()
-    model = LogisticRegression(penalty='elasticnet', solver='saga')
-    pipeline.steps.append(('model', model))
-    k_folds = KFold(n_splits=5)
-    param_grid = {'model__l1_ratio': [0.25, 0.5, 0.75]}
-    clf = GridSearchCV(pipeline, param_grid=param_grid, scoring=scoring,
-                       cv=k_folds, refit=refit)
-    logger.info(f"fitting model with {clf.get_params()}")
-    clf.fit(features, labels)
-    return clf
+    tuner_cls = TrainingSchema.MODEL_CHOICES[model]
+    optimizer = TrainingSchema.OPTIMIZER_CHOICES[optimizer]
+    tuner = tuner_cls(features, labels, pipeline, n_splits=n_folds,
+                      scorer=scorer, opt_algo=optimizer, seed=seed)
+
+    # Tune with CV and fit to training data
+    logger.info(f"Fitting {model} to data (n={len(features)}).")
+    start_time = time.time()
+    logger.info(f"Optimizing '{scorer}' over {max_iter} iterations...")
+    best_params = tuner.fmax(max_iter)
+    end_time = time.time()
+    logger.info(f"Considered {max_iter} trials over "
+                f"{end_time-start_time} seconds. "
+                f"Best Score: {-tuner.trials.best_trial['result']['loss']}\n"
+                f"Best Params: {best_params}")
+    clf = tuner.classifier(**best_params)
+    pipeline.steps.append(("classifier", clf))
+    logger.info(f"Fitting {model} model to training data with {best_params}")
+    pipeline.fit(features, labels)
+
+    # Compute cross-validation score for optimization metric
+    # Note that this metric will be an optimistic estimate of performance,
+    # since we are not using nested cross-validation
+    cv = KFold(n_splits=n_folds, shuffle=True, random_state=seed)
+    opt_score = (scorer, cross_val_score(
+        pipeline, features, labels, scoring=scorer, cv=cv))
+
+    # Compute metrics for test data
+    # Default to just computing the optimization metric on test data
+    test_metrics = test_metrics or [scorer]
+    test_metrics = {
+        f"test_{metric}":
+            get_scorer(metric)(pipeline, test_features, test_labels)
+        for metric in test_metrics}
+
+    # Compute confusion matrix for arbitrary metric calculation
+    cmat = _binary_confusion_dict(
+        test_labels, pipeline.predict(test_features), "test_")
+
+    # Refit on full data if applicable
+    if refit:
+        full_features = pd.concat([features, test_features], axis=0)
+        full_labels = labels + test_labels
+        pipeline.fit(full_features, full_labels)
+    return pipeline, opt_score, test_metrics, cmat
 
 
 def mlflow_log_classifier(training_data_path: str,
                           test_data_path: str,
-                          clf: GridSearchCV) -> str:
-    """Logs a classifier with mlflow
+                          clf: GridSearchCV,
+                          cv_scores: tuple,
+                          metrics: Optional[dict] = None,
+                          confusion_matrix: Optional[np.ndarray] = None,
+                          tags: Optional[dict] = None) -> str:
+    """Logs a classifier with mlflow.
 
     Parameters
     ----------
@@ -95,75 +490,184 @@ def mlflow_log_classifier(training_data_path: str,
         path or URI of the training data
     test_data_path: str
         path or URI of the test data
+    score: tuple
+        Tuple of (<score name>, <scores per fold>) for optimization
+        metric (training data). Encouraged by scikit-learn's model
+        persistence page to ensure reproducibility.
     clf: GridSeachCV
         a trained classifier
-
+    metrics: dict
+        Optional dictionary of {<score name>, <value>} for scored
+        metrics on test data.
+        Example: {"accuracy": 0.95, "precision": 0.89}.
+    confusion_matrix: dict
+        An optional confusion matrix for classifier results. If
+        included, will allow computing arbitrary metrics from the
+        model performance log. The keys should be all of the following:
+        "TN", "TP", "FN", "FP" (true negative, true positive, etc.).
+        The values should be the counts for each of these possible
+        keys (not normalized).
+    tags: dict (default=None)
+        An optional dictionary of tags. By default will tag the
+        paths to the train and test data, and the scikit-learn version
+        used to train the model.
     Returns
     -------
     run_id: str
         the mlflow-assigned run_id
-
     """
     # log the run
-    with mlflow.start_run() as mlrun:
-        mlflow.set_tags({'training_data_path': training_data_path,
-                         'param_grid': clf.param_grid})
+    mlrun = mlflow.start_run()
+    tags = tags or {}
+    mlflow.set_tags({"training_data_path": training_data_path,
+                     "test_data_path": test_data_path,
+                     "sklearn_version": sklearn.__version__,
+                     **tags})
+    # Log the CV scores for optimization metric
+    # This is important for reproducibility
+    # See https://scikit-learn.org/stable/modules/model_persistence.html
+    for ix, score in enumerate(cv_scores[1]):
+        mlflow.log_metric(f"split{ix}_train_{cv_scores[0]}", score)
 
-        for k, v in clf.best_params_.items():
-            mlflow.log_metric(k, v)
-        for score_key in clf.scorer_.keys():
-            keys = [f"split{i}_test_{score_key}"
-                    for i in range(clf.n_splits_)]
-            for k in keys:
-                mlflow.log_metric(k, clf.cv_results_[k][clf.best_index_])
+    # Now log the test scores if given
+    if metrics:
+        mlflow.log_metrics(metrics)
 
-        # log and save fitted model
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tmp_model_path = Path(temp_dir) / "trained_model.joblib"
-            joblib.dump(clf.best_estimator_, tmp_model_path)
-            mlflow.log_artifact(str(tmp_model_path))
+    # log and save fitted model
+    with tempfile.TemporaryDirectory() as temp_dir:
+        tmp_model_path = Path(temp_dir) / "trained_model.joblib"
+        joblib.dump(clf, tmp_model_path)
+        mlflow.log_artifact(str(tmp_model_path))
 
-        # run the model on test_data
-        test_data = json_load_local_or_s3(test_data_path)
-        features = FeatureExtractor.from_list_of_dict(test_data).run()
-        y_true = [r['label'] for r in test_data]
-        y_pred = clf.predict(features)
-
-        mlflow.log_metric('test_accuracy', accuracy_score(y_true, y_pred))
-        cmat = confusion_matrix(y_true, y_pred)
-        for i in [0, 1]:
-            for j in [0, 1]:
-                mlflow.log_metric(f"count_{i}_{j}", int(cmat[i, j]))
-
-        run_id = mlrun.info.run_id
-
+    # Log confusion matrix
+    if confusion_matrix is not None:
+        mlflow.log_metrics(confusion_matrix)
+    run_id = mlrun.info.run_id
+    mlflow.end_run()
     return run_id
 
 
+class TrainingSchema(argschema.ArgSchema):
+    """Schema for parsing arguments to the main module behavior."""
+
+    MODEL_CHOICES = {"RandomForestClassifier": RandomForestTuner,
+                     "LogisticRegression": LogisticRegressionTuner}
+    OPTIMIZER_CHOICES = {"tpe": tpe.suggest, "rand": tpe.rand.suggest}
+
+    training_data = argschema.fields.Str(
+        required=True,
+        description=("s3 uri or local path, <stem>.json containing a list "
+                     "of dicts, where each dict can be passed into "
+                     "RoiWithMetaData.from_dict()."))
+    test_data = argschema.fields.Str(
+        required=True,
+        description=("s3 uri or local path, <stem>.json containing a list "
+                     "of dicts, where each dict can be passed into "
+                     "RoiWithMetaData.from_dict()."))
+    scorer = argschema.fields.Str(
+        required=False,
+        missing="roc_auc",
+        description=("Optimization metric for the model. All scorers follow "
+                     "the convention that higher return values are better "
+                     "than lower return values. See "
+                     "https://scikit-learn.org/stable/modules/model_evaluation.html#scoring-parameter"))  # noqa
+    reported_metrics = argschema.fields.List(
+        argschema.fields.Str,
+        required=False,
+        missing=["roc_auc"],
+        cli_as_single_argument=True,
+        description=("Metrics to report to mlflow, in addition to the scorer "
+                     "(optimization metric)."))
+    model = argschema.fields.Str(
+        required=False,
+        missing="RandomForestClassifier",
+        validate=mm.validate.OneOf(list(MODEL_CHOICES)),
+        description=(f"Choice of model. Must be one of {list(MODEL_CHOICES)}")
+    )
+    max_iter = argschema.fields.Int(
+        required=False,
+        missing=100,
+        validate=lambda x: x > 0,
+        description=("Number of trials to conduct hyperparameter tuning.")
+    )
+    refit = argschema.fields.Bool(
+        required=False,
+        missing=True,
+        description="Whether to refit model on full data (train+test set)."
+    )
+    seed = argschema.fields.Int(
+        required=False,
+        missing=42,
+        description=("Random seed to reproduce folds, etc.")
+    )
+    optimizer = argschema.fields.Str(
+        required=False,
+        missing="tpe",
+        validate=mm.validate.OneOf(["tpe", "rand"]),
+        description=("Optimizer to use for hyperparamter tuning. One of "
+                     "'rand' (random search) or 'tpe' (Bayesian optimization)")
+    )
+    n_folds = argschema.fields.Int(
+        required=False,
+        missing=5,
+        validate=lambda x: x > 0,
+        description="Number of folds for k-fold cross-validation."
+    )
+
+    @mm.post_load
+    def validate_s3_or_input(self, data, **kwargs):
+        for k in ["training_data", "test_data"]:
+            if not data[k].startswith("s3://"):
+                argschema.fields.files.validate_input_path(data[k])
+            else:
+                uri = urlparse(data[k])
+                if not object_exists(uri.netloc, uri.path[1:]):
+                    raise mm.ValidationError(f"{uri.geturl()} does not exist")
+        return data
+
+
 class ClassifierTrainer(argschema.ArgSchemaParser):
+    """Main module entry point."""
     default_schema = TrainingSchema
 
     def train(self):
         self.logger.name = type(self).__name__
-        self.logger.setLevel(self.args.pop('log_level'))
+        self.logger.setLevel(self.args.pop("log_level"))
+
+        tags = {"model": self.args["model"],
+                "metric": self.args["scorer"],
+                "seed": self.args["seed"],
+                "n_folds": self.args["n_folds"],
+                "max_iter": self.args["max_iter"],
+                "optimizer": self.args["optimizer"],
+                "refit": self.args["refit"]}
 
         # train the classifier
-        clf = train_classifier(
-                training_data_path=self.args['training_data'],
-                scoring=self.args['scoring'],
-                refit=self.args['refit'])
-        self.logger.info(
-            f"Model fit, with best score {clf.best_score_} "
-            f"and best parameters {clf.best_params_}.")
+        clf, cv_scores, test_metrics, confusion_matrix = train_classifier(
+                model=self.args["model"],
+                training_data_path=self.args["training_data"],
+                test_data_path=self.args["test_data"],
+                scorer=self.args["scorer"],
+                max_iter=self.args["max_iter"],
+                optimizer=self.args["optimizer"],
+                test_metrics=self.args["reported_metrics"],
+                n_folds=self.args["n_folds"],
+                seed=self.args["seed"],
+                refit=self.args["refit"])
 
         # log the training
         run_id = mlflow_log_classifier(
-                self.args['training_data'],
-                self.args['test_data'],
-                clf)
+                self.args["training_data"],
+                self.args["test_data"],
+                clf,
+                cv_scores,
+                metrics=test_metrics,
+                confusion_matrix=confusion_matrix,
+                tags=tags
+        )
         self.logger.info(f"logged training to mlflow run {run_id}")
 
 
-if __name__ == '__main__':  # pragma no cover
+if __name__ == "__main__":  # pragma no cover
     trainer = ClassifierTrainer()
     trainer.train()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ jsonlines
 s3fs
 psycopg2-binary
 typing_extensions
+hyperopt
+hpsklearn

--- a/test/test_online_training.py
+++ b/test/test_online_training.py
@@ -5,7 +5,14 @@ import pytest
 import os
 
 
-def test_online_training_schema(tmp_path):
+@pytest.fixture()
+def temp_file(tmp_path):
+    fp = tmp_path / "hello.txt"
+    fp.write_text("hello world")
+    yield str(fp)
+
+
+def test_online_training_schema(tmp_path, temp_file):
     tmp_env_var = None
     if "MLFLOW_EXPERIMENT" in os.environ.keys():
         tmp_env_var = os.environ.pop("MLFLOW_EXPERIMENT")
@@ -14,8 +21,8 @@ def test_online_training_schema(tmp_path):
 
     outj = tmp_path / "output.json"
     training_args = {
-            "training_data": "some string",
-            "test_data": "some other string"
+            "training_data": temp_file,
+            "test_data": temp_file,
             }
     args = {
             "output_json": str(outj),
@@ -35,15 +42,15 @@ def test_online_training_schema(tmp_path):
         os.environ["MLFLOW_EXPERIMENT"] = tmp_env_var
 
 
-def test_online_training_schema_exception(tmp_path):
+def test_online_training_schema_exception(tmp_path, temp_file):
     tmp_env_var = None
     if "MLFLOW_EXPERIMENT" in os.environ.keys():
         tmp_env_var = os.environ.pop("MLFLOW_EXPERIMENT")
 
     outj = tmp_path / "output.json"
     training_args = {
-            "training_data": "some string",
-            "test_data": "some other string"
+            "training_data": temp_file,
+            "test_data": temp_file,
             }
     args = {
             "output_json": str(outj),
@@ -62,11 +69,11 @@ def test_online_training_schema_exception(tmp_path):
         os.environ["MLFLOW_EXPERIMENT"] = tmp_env_var
 
 
-def test_online_training(tmp_path, monkeypatch):
+def test_online_training(tmp_path, temp_file, monkeypatch):
     outj = tmp_path / "output.json"
     training_args = {
-            "training_data": "some string",
-            "test_data": "some other string"
+            "training_data": temp_file,
+            "test_data": temp_file,
             }
     args = {
             "output_json": str(outj),

--- a/test/test_train.py
+++ b/test/test_train.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 
 import pytest
 import mlflow
-# import mlflow.sklearn
 from moto import mock_s3
 import boto3
 import argschema

--- a/test/test_train.py
+++ b/test/test_train.py
@@ -1,15 +1,33 @@
 from pathlib import Path
 import json
-import pytest
-from unittest.mock import MagicMock
-import mlflow
-import mlflow.sklearn
-import joblib
+import os
 from functools import partial
+from urllib.parse import urlparse
+from unittest.mock import MagicMock
+
+import pytest
+import mlflow
+# import mlflow.sklearn
+from moto import mock_s3
+import boto3
+import argschema
+import marshmallow as mm
+import sklearn
+
+from hyperopt import hp
+from sklearn.metrics import brier_score_loss, make_scorer
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.datasets import load_breast_cancer
+
 import croissant.train as train
 from croissant.features import FeatureExtractor
-import os
-import numpy as np
+
+
+@pytest.fixture()
+def X_y():
+    """Random dataset and features"""
+    return load_breast_cancer(return_X_y=True)
 
 
 @pytest.fixture()
@@ -27,15 +45,8 @@ def test_data():
 @pytest.fixture
 def mock_classifier(request):
     mock_clf = MagicMock()
-    mock_clf.n_splits_ = 5
-    mock_clf.best_index_ = 0
-    mock_clf.best_score_ = request.param['best_score']
-    mock_clf.best_params_ = request.param['best_params']
-    mock_clf.param_grid = request.param['param_grid']
-    mock_clf.cv_results_ = request.param['results']
-    mock_clf.scorer_ = {request.param['scorer']: 'sklearn_callable'}
-    mock_clf.best_estimator_ = request.param['pickled']
     mock_clf.n_test = request.param['n_test_values']
+    mock_clf.pickled = request.param["pickled"]
     mock_clf.predict = MagicMock(return_value=[0] * mock_clf.n_test)
     return mock_clf
 
@@ -48,13 +59,67 @@ def mock_FeatureExtractor():
     yield mock_FE
 
 
-def test_train_classifier(train_data, test_data, tmp_path):
+@pytest.fixture
+def experiment_name():
+    return "myexperiment"
+
+
+@pytest.fixture
+def mlflow_client(experiment_name, tmp_path):
+    """
+    MLFlow can't nicely be mocked to stay in-memory, so we need to
+    do some setup for testing.
+
+    In production, we plan to run from the command line with
+    `mlflow run ...` This setup block is equivalent to the following
+    mlflow CLI call:
+
+    > mlflow experiments create \
+            --experiment-name <ename> \
+            --artifact-location <path>
+
+    and then, when running from the MLProject file
+    > mlflow run . --experiment-name <ename> ...
+
+    mlflow run reads the tracking URI from the env variable
+    MLFLOW_TRACKING_URI
+        experiment_name = "myexperiment"
+        artifact_uri = str(tmp_path / "artifacts")
+        tracking_uri = str(tmp_path / "tracking")
+        os.environ['MLFLOW_TRACKING_URI'] = str(tracking_uri)
+        mlflow.create_experiment(
+                experiment_name, artifact_location=artifact_uri)
+        mlflow.set_experiment(experiment_name)
+    """
+    experiment_name = experiment_name
+    artifact_uri = str(tmp_path / "artifacts")
+    tracking_uri = str(tmp_path / "tracking")
+    os.environ['MLFLOW_TRACKING_URI'] = str(tracking_uri)
+    mlflow.create_experiment(
+            experiment_name, artifact_location=artifact_uri)
+    mlflow.set_experiment(experiment_name)
+    client = mlflow.tracking.MlflowClient(
+        tracking_uri=str(tracking_uri))
+    yield client
+
+
+@pytest.mark.parametrize(
+    "model", ["RandomForestClassifier", "LogisticRegression"]
+)
+def test_train_classifier_binary_preds(
+        model, train_data, test_data, tmp_path):
     """tests that `train_classifier()` generates a classifier that
     makes binary predictions.
     """
-    clf = train.train_classifier(training_data_path=train_data,
-                                 scoring=['roc_auc'],
-                                 refit='roc_auc')
+    clf, _, _, _ = train.train_classifier(
+        model=model,
+        training_data_path=train_data,
+        test_data_path=test_data,
+        scorer='roc_auc',
+        max_iter=2,
+        optimizer="rand",
+        n_folds=2,
+        refit=True)
 
     # load testing roi and generate input features
     with open(test_data, 'r') as open_testing:
@@ -66,119 +131,206 @@ def test_train_classifier(train_data, test_data, tmp_path):
 
 
 @pytest.mark.parametrize(
-        "mock_classifier",
+    "model", ["RandomForestClassifier", "LogisticRegression"]
+)
+@pytest.mark.parametrize(
+    "scorer,n_folds,test_metrics,optimizer,refit",
+    [
+        ("accuracy", 3, ["roc_auc", "average_precision"], "rand", True),
+        ("recall", 2, None, "tpe", False),
+    ]
+)
+def test_train_classifier_integration(
+        train_data, test_data, model, scorer, n_folds, test_metrics,
+        optimizer, refit):
+    """Are we playing nicely with sklearn, etc."""
+    actual_pipe, actual_opt_score, actual_metrics, actual_cmat = (
+        train.train_classifier(
+            model,
+            train_data,
+            test_data,
+            scorer,
+            max_iter=1,
+            optimizer=optimizer,
+            test_metrics=test_metrics,
+            n_folds=n_folds,
+            seed=42,
+            refit=refit
+        )
+    )
+
+    # test correct number of values for optimization metric folds
+    assert n_folds == len(actual_opt_score[1])
+    # test correct scorer
+    assert scorer == actual_opt_score[0]
+    # test correct test metrics evaluated
+    if test_metrics is not None:
+        expected_test_metrics = [f"test_{m}" for m in test_metrics]
+        assert len(actual_metrics) == len(expected_test_metrics)
+        assert set(actual_metrics).issubset(expected_test_metrics)
+    else:
+        assert list(actual_metrics) == [f"test_{scorer}"]
+    # test chose the correct model
+    assert model in str(actual_pipe[-1].__class__)
+    # test confusion matrix formatted correctly
+    assert len(actual_cmat) == 4
+    assert set(actual_cmat).issubset(
+        ["test_TN", "test_TP", "test_FN", "test_FP"])
+
+
+@pytest.mark.parametrize(
+    "y_true, y_pred, prefix, expected",
+    [
+        (
+            [1, 0, 0, 1, 1],
+            [1, 0, 1, 1, 1],
+            "",
+            {"TN": 1, "TP": 3, "FN": 0, "FP": 1}
+        ),
+        (
+            [0, 1, 1, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1],
+            "test_",
+            {"test_TN": 0, "test_TP": 2, "test_FN": 0, "test_FP": 4}
+        )
+    ]
+)
+def test_binary_confusion_dict(y_true, y_pred, prefix, expected):
+    actual = train._binary_confusion_dict(y_true, y_pred, prefix=prefix)
+    assert expected == actual
+
+
+@pytest.mark.parametrize(
+    "y_true,y_pred,",
+    [([0, 1, 1, 1, 2], [0, 0, 0, 1, 1])]
+)
+def test_binary_confusion_dict_raises_error_non_binary(y_true, y_pred):
+    with pytest.raises(ValueError, match=r"Must have binary labels"):
+        train._binary_confusion_dict(y_true, y_pred)
+
+
+@pytest.mark.parametrize(
+    "tags,metrics,confusion_matrix",
+    [
+        (
+            {"never": "gonna", "give": "you"},
+            {"up": 0.867, "never": 0.5309},
+            {"TP": 13, "TN": 15, "FP": 1, "FN": 0},
+        ),
+        (None, None, None)      # Testing optional args
+    ]
+)
+@pytest.mark.parametrize(
+        "train_path,test_path,mock_classifier,cv_scores,expected_cv",
         [
-            ({
-                'best_score': 123,
-                'best_params': {'a': 1, 'b': 2.0},
-                'param_grid': {'p1': [4, 5, 6.7]},
-                'scorer': "metric1",
-                'results': {
-                    'split0_test_metric1': [0.1, 0.2, 0.3, 0.4, 0.5],
-                    'split1_test_metric1': [0.1, 0.2, 0.3, 0.4, 0.5],
-                    'split2_test_metric1': [0.1, 0.2, 0.3, 0.4, 0.5],
-                    'split3_test_metric1': [0.1, 0.2, 0.3, 0.4, 0.5],
-                    'split4_test_metric1': [0.1, 0.2, 0.3, 0.4, 0.5],
-                    },
-                'pickled': {'something': ['to', 'pickle']},
-                'n_test_values': 100
-                }),
-            ], indirect=["mock_classifier"])
-def test_mlflow_log_classifier(tmp_path, mock_classifier,
-                               mock_FeatureExtractor, monkeypatch):
-    """with a mocked classifier, tests that `mlflow_log_classifier()` logs
-    to mlflow
-
-    Notes
-    -----
-    in production, we plan to run from the command line with `mlflow run ...`
-    the first block below, labeled "setup block" will have the equivalent
-    CLI setup of
-    > mlflow experiments create \
-            --experiment-name <ename> \
-            --artifact-location <path>
-
-    and then, when running from the MLProject file
-    > mlflow run . --experiment-name <ename> ...
-
-    mlflow run reads the tracking URI from the env variable
-    MLFLOW_TRACKING_URI
-
+            (
+                "/fake/path/file.txt",
+                "s3://fake/path/file_2.txt",
+                {
+                    "n_test_values": 100,
+                    "pickled": {"a": "b"}
+                },
+                ("accuracy", [0.9, 0.8, 0.7]),
+                {"split0_train_accuracy": 0.9,
+                    "split1_train_accuracy": 0.8,
+                    "split2_train_accuracy": 0.7}
+            )
+        ], indirect=["mock_classifier"])
+def test_mlflow_log_classifier(
+        tmp_path, train_path, test_path, mock_classifier, cv_scores,
+        metrics, confusion_matrix, tags, expected_cv, monkeypatch,
+        experiment_name, mlflow_client):
     """
-    # setup block
-    experiment_name = "myexperiment"
-    artifact_uri = str(tmp_path / "artifacts")
-    tracking_uri = str(tmp_path / "tracking")
-    os.environ['MLFLOW_TRACKING_URI'] = str(tracking_uri)
-    mlflow.create_experiment(
-            experiment_name, artifact_location=artifact_uri)
-    mlflow.set_experiment(experiment_name)
-    # end of setup block
+    Test mlflow logging behavior with mocked classifier
+    """
+    def _mock_dump(obj, path):
+        with open(path, "w") as f:
+            json.dump(obj.pickled, f)
 
-    # patch the FeatureExtractor call for testing
-    mpatcher = partial(monkeypatch.setattr, target=train)
-    mpatcher(name="FeatureExtractor", value=mock_FeatureExtractor)
-
-    # make a file with some labels in it
-    test_json = tmp_path / "test_labels.json"
-    labels = np.random.randint(0, 2, mock_classifier.n_test, dtype=int)
-    with open(test_json, "w") as f:
-        json.dump([{'label': int(i)} for i in labels], f)
-
-    training_data_path = "some_string"
+    monkeypatch.setattr(train.joblib, "dump", _mock_dump)
     run_id = train.mlflow_log_classifier(
-            training_data_path,
-            str(test_json),
-            mock_classifier)
+            train_path,
+            test_path,
+            mock_classifier,
+            cv_scores,
+            metrics,
+            confusion_matrix,
+            tags)
 
     # check that this call adds a run to mlflow
-    client = mlflow.tracking.MlflowClient(tracking_uri=str(tracking_uri))
-    experiment = client.get_experiment_by_name(experiment_name)
-    run_infos = client.list_run_infos(experiment.experiment_id)
+    experiment = mlflow_client.get_experiment_by_name(experiment_name)
+    run_infos = mlflow_client.list_run_infos(experiment.experiment_id)
     run_ids = [r.run_id for r in run_infos]
     assert run_id in run_ids
 
     # check that this run has the right stuff
-    myrun = client.get_run(run_id)
+    myrun = mlflow_client.get_run(run_id)
+
     # metrics
-    for k, v in mock_classifier.best_params_.items():
+    combo_expected_metrics = {}
+    combo_expected_metrics.update(metrics or {})
+    combo_expected_metrics.update(confusion_matrix or {})
+    combo_expected_metrics.update(expected_cv)
+    for k, v in combo_expected_metrics.items():
         assert k in myrun.data.metrics
         assert myrun.data.metrics[k] == v
-    for k in mock_classifier.cv_results_.keys():
-        assert k in myrun.data.metrics
+
     # tags
+    if tags is None:
+        tags = {}       # make an iterable
     expected_tags = {
-            'training_data_path': training_data_path,
-            'param_grid': repr(mock_classifier.param_grid)
+            "training_data_path": train_path,
+            "test_data_path": test_path,
+            "sklearn_version": sklearn.__version__,
+            **tags
             }
     for k, v in expected_tags.items():
         assert k in myrun.data.tags
         assert myrun.data.tags[k] == v
+
     # artifact
-    artifacts = client.list_artifacts(run_id)
+    artifacts = mlflow_client.list_artifacts(run_id)
     artifact_paths = [a.path for a in artifacts]
     model = "trained_model.joblib"
     assert model in artifact_paths
     my_artifact_path = Path(myrun.info.artifact_uri) / model
     assert my_artifact_path.exists()
-    unpickled = joblib.load(my_artifact_path)
-    assert unpickled == mock_classifier.best_estimator_
 
 
 def test_ClassifierTrainer(train_data, test_data, tmp_path, monkeypatch):
     """tests argschema entry point with mocked training and logging
     """
     args = {
-            "training_data": str(train_data),
-            "test_data": str(test_data),
-            'scoring': ['a'],
-            'refit': 'a',
-            }
+        "training_data": str(train_data),
+        "test_data": str(test_data),
+        "scorer": "accuracy",
+        "reported_metrics": ["roc_auc"],
+        "model": "LogisticRegression",
+        "max_iter": 2,
+        "refit": True,
+        "seed": 99,
+        "optimizer": "rand",
+        "n_folds": 3
+    }
 
     mock_classifier = MagicMock()
-    mock_classifier.best_score_ = "a good score"
-    mock_classifier.best_params_ = "some good params"
-    mock_train_classifier = MagicMock(return_value=mock_classifier)
+    # mock_classifier.best_score_ = "a good score"
+    # mock_classifier.best_params_ = "some good params"
+    mock_train_classifier = MagicMock(
+        return_value=(
+            mock_classifier,
+            ("score", [0.9, 0.8, 0.7]),
+            {"test_score": 0.8},
+            {"TN": 1, "TP": 1, "FN": 1, "FP": 1}))
+
+    tags = {"model": args["model"],
+            "metric": args["scorer"],
+            "seed": args["seed"],
+            "n_folds": args["n_folds"],
+            "max_iter": args["max_iter"],
+            "optimizer": args["optimizer"],
+            "refit": args["refit"]}
+
     mock_mlflow_log_classifier = MagicMock()
     mpatcher = partial(monkeypatch.setattr, target=train)
     mpatcher(name="train_classifier", value=mock_train_classifier)
@@ -188,11 +340,150 @@ def test_ClassifierTrainer(train_data, test_data, tmp_path, monkeypatch):
     ctrain.train()
 
     mock_train_classifier.assert_called_once_with(
+            model=args["model"],
             training_data_path=train_data,
-            scoring=args['scoring'],
-            refit=args['refit'])
+            test_data_path=test_data,
+            scorer=args["scorer"],
+            max_iter=args["max_iter"],
+            optimizer=args["optimizer"],
+            test_metrics=args["reported_metrics"],
+            n_folds=args["n_folds"],
+            seed=args["seed"],
+            refit=args["refit"]
+    )
 
     mock_mlflow_log_classifier.assert_called_once_with(
             args['training_data'],
             args['test_data'],
-            mock_classifier)
+            mock_classifier,
+            ("score", [0.9, 0.8, 0.7]),
+            metrics={"test_score": 0.8},
+            confusion_matrix={"TN": 1, "TP": 1, "FN": 1, "FP": 1},
+            tags=tags)
+
+
+@pytest.fixture(scope="module")
+def s3_file():
+    file_uri = "s3://myschematest/my/file.json"
+    mock = mock_s3()
+    mock.start()
+    test_up = urlparse(file_uri)
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket=test_up.netloc)
+    resp = s3.put_object(Bucket=test_up.netloc, Key=test_up.path[1:],
+                         Body=json.dumps({'a': 1}).encode('utf-8'))
+    print(resp)
+    yield file_uri
+    mock.stop()
+
+
+class TestTrainingSchema:
+
+    def test_training_schema_works(self, s3_file):
+        args = {
+            "training_data": s3_file,
+            "test_data": s3_file
+        }
+        # uris exist, no errors
+        argschema.ArgSchemaParser(input_data=args,
+                                  schema_type=train.TrainingSchema,
+                                  args=[])
+
+    def test_training_schema_fails_nonexistent_data(self, s3_file):
+        args = {
+            "training_data": "s3://myschematest/does/not/exist.txt",
+            "test_data": s3_file
+        }
+        with pytest.raises(mm.ValidationError, match=r".*does not exist"):
+            argschema.ArgSchemaParser(input_data=args,
+                                      schema_type=train.TrainingSchema,
+                                      args=[])
+
+    def test_training_schema_fails_bad_model(self, s3_file):
+        args = {
+            "training_data": s3_file,
+            "test_data": s3_file,
+            "model": "SomeRandomAlgorithm"
+        }
+        with pytest.raises(mm.ValidationError, match=r"Must be one of"):
+            argschema.ArgSchemaParser(input_data=args,
+                                      schema_type=train.TrainingSchema,
+                                      args=[])
+
+    def test_training_schema_fails_bad_optimizer(self, s3_file):
+        args = {
+            "training_data": s3_file,
+            "test_data": s3_file,
+            "optimizer": "CoolOptimizer"
+        }
+        with pytest.raises(mm.ValidationError, match=r"Must be one of"):
+            argschema.ArgSchemaParser(input_data=args,
+                                      schema_type=train.TrainingSchema,
+                                      args=[])
+
+
+@pytest.mark.parametrize(
+    "param_space, expected_params", [
+        (None, ["bootstrap", "max_depth", "max_features", "min_samples_leaf",
+                "min_samples_split", "n_estimators", "oob_score"]),
+        ({"max_depth":
+          hp.choice("max_depth", [1, 5, 10])}, ["max_depth"])
+    ]
+)
+@pytest.mark.parametrize(
+    "pipeline,n_splits,scorer,low_good",
+    [
+        (None, 5, "roc_auc", False,),
+        (Pipeline(steps=[("scaler", StandardScaler())]), 3,
+         make_scorer(brier_score_loss), True,),
+    ]
+)
+def test_RandomForestTuner_fmin_fmax(
+        X_y, param_space, pipeline, n_splits, scorer, low_good,
+        expected_params):
+    X, y = X_y
+    tuner = train.RandomForestTuner(X, y, pipeline, param_space=param_space,
+                                    n_splits=n_splits, scorer=scorer)
+    if low_good:
+        best_params = tuner.fmin(2)
+    else:
+        best_params = tuner.fmax(2)
+
+    assert 2 == len(tuner.trials), "Did not evaluate correct number of trials."
+    for param in expected_params:
+        assert param in best_params.keys(), (
+            f"Missing expected param {param} in best param set.")
+
+
+@pytest.mark.parametrize(
+    "param_space, expected_params", [
+        (None, ["C", "penalty", "l1_ratio"]),
+        ({"penalty": "l2",
+          "solver": hp.choice("solver", ["newton-cg", "sag", "lbfgs"])},
+         ["penalty", "solver"])
+    ]
+)
+@pytest.mark.parametrize(
+    "pipeline,n_splits,scorer,low_good",
+    [
+        (None, 5, "roc_auc", False,),
+        (Pipeline(steps=[("scaler", StandardScaler())]), 3,
+         make_scorer(brier_score_loss), True,),
+    ]
+)
+def test_LogisticRegressionTuner_fmin_fmax(
+        X_y, param_space, pipeline, n_splits, scorer, low_good,
+        expected_params):
+    X, y = X_y
+    tuner = train.LogisticRegressionTuner(
+        X, y, pipeline, param_space=param_space,
+        n_splits=n_splits, scorer=scorer)
+    if low_good:
+        best_params = tuner.fmin(2)
+    else:
+        best_params = tuner.fmax(2)
+
+    assert 2 == len(tuner.trials), "Did not evaluate correct number of trials."
+    for param in expected_params:
+        assert param in best_params.keys(), (
+            f"Missing expected param {param} in best param set.")

--- a/test/test_train.py
+++ b/test/test_train.py
@@ -83,13 +83,6 @@ def mlflow_client(experiment_name, tmp_path):
 
     mlflow run reads the tracking URI from the env variable
     MLFLOW_TRACKING_URI
-        experiment_name = "myexperiment"
-        artifact_uri = str(tmp_path / "artifacts")
-        tracking_uri = str(tmp_path / "tracking")
-        os.environ['MLFLOW_TRACKING_URI'] = str(tracking_uri)
-        mlflow.create_experiment(
-                experiment_name, artifact_location=artifact_uri)
-        mlflow.set_experiment(experiment_name)
     """
     experiment_name = experiment_name
     artifact_uri = str(tmp_path / "artifacts")


### PR DESCRIPTION
Use [hyperopt](http://hyperopt.github.io/hyperopt/) to tune models. For each hyperparameter "trial", sample the hyperparameter space. Use the sampled params to train a model with k-fold cross validation. Compute the average score of the optimization metric over the folds. Return the best parameters found and retrain the model on the training set using those parameters (optionally refit to include the test set). Compute metrics on the train and test sets and log them to mlflow.

The design of the classes are easy to use for interactive, notebook-based data exploration/model prototyping. By including intelligent defaults in the model-specific tuner classes, they should be able to be effectively used in scripts as long as the search space is well-defined and number of iterations is sufficiently large (for RandomForestClassifier -- LogisticRegression doesn't really have a lot of tunable parameters).


Notable changes compared to previous version:

0. Add the tuning capabilities
1. Update arguments for entry into the module. All added arguments have defaults so are not required.
2. Compute all metrics before entering into the mlflow log block.
3. Potentially refit model on all data (train + test)
4. Update the mlflow tagging and add metrics
5. Update the way we store confusion matrix (use the labeled keys "TP", "TF", etc.)
6. Update some of the online_training tests that were failing on my machine during schema validation (from files that don't exist)


Edit: Additional Validation
I set up our cloud infrastructure and got it running. Note that we will need to update the docker image that the stack points to. We should probably automate this in circleCI on merge to master.

I ran a model with 1000 hyperopt trials using our very small feature set. 
`run_id= f887d2be2bad43b68143f8d7787178a0`
All tags and params logged in mlflow as expected.
Here's the model artifact: `s3://prod.croissant-artifacts.alleninstitute.org/f887d2be2bad43b68143f8d7787178a0/artifacts/trained_model.joblib`
Here are the results: 
```
INFO:TrainClassifier:Considered 1000 trials over 1437.4327154159546 seconds. Best Score: 0.8294377932372532
Best Params: {'bootstrap': False, 'max_depth': None, 'max_features': 'sqrt', 'min_samples_leaf': 10, 'min_samples_split': 2, 'n_estimators': 101, 'n_jobs': 1, 'oob_score': False, 'random_state': 42, 'verbose': False}
```
![Screen Shot 2020-08-11 at 12 29 18 PM](https://user-images.githubusercontent.com/34227334/89940447-6146d780-dbce-11ea-9986-48a03ac08b3d.png)
