### PR TITLE
GH 41 & 53: Additional features from feature exploration, with columns in deterministic order

### DIFF
--- a/croissant/features.py
+++ b/croissant/features.py
@@ -1,15 +1,44 @@
 from __future__ import annotations  # noqa
-from typing import Union, List, Dict, Any
+from typing import Union, List, Dict, Any, Callable, Iterable
+from functools import partial
+import inspect
+from itertools import chain
 
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.compose import ColumnTransformer
+from sklearn.neighbors import KDTree
 from scipy.sparse import coo_matrix
 from scipy.stats import skew
 import numpy as np
 import pandas as pd
 
 from croissant.roi import Roi, RoiMetadata, RoiWithMetadata
+from croissant.utils import is_prefixed_function_or_method
+
+
+class NeighborhoodInfo(object):
+    """Bundle the KDTree queries"""
+    def __init__(self, roi):
+        self.coords = list(zip(roi.col, roi.row))
+        self.tree = KDTree(np.array(self.coords), leaf_size=10)
+
+    def neighbor_dist(self, n=1):
+        """n-nearest neighbors (not including itself)"""
+        # Avoid ValueError if there's only one data point
+        if len(self.coords) == 1:
+            return (0, 0, 0)
+        dist, _ = self.tree.query(self.coords, k=n+1)
+        near_dist = [d[1] for d in dist]
+        return np.mean(near_dist), np.std(near_dist), skew(near_dist)
+
+    def adjacent_pixels(self):
+        """number of adjacent pixels (including diagonal)
+        Simple, will 'double-count'"""
+        ind = self.tree.query_radius(self.coords, r=1.42)
+        vec_len = np.vectorize(len)
+        n_neighbors = vec_len(ind) - 1    # Don't want itself as a neighbor
+        return np.mean(n_neighbors), np.std(n_neighbors), skew(n_neighbors)
 
 
 class FeatureExtractor:
@@ -18,7 +47,9 @@ class FeatureExtractor:
     def __init__(self,
                  rois: Union[List[Roi], List[coo_matrix]],
                  dff_traces: List[List[float]],
-                 metadata: List[RoiMetadata]):
+                 metadata: List[RoiMetadata],
+                 id_col: str = "id",
+                 spike_stddev_threshold: float = 2.5):
         """
         Each index in rois, dff_traces, and metadata should correspond
         to the same index in the other sources. That is, the roi mask
@@ -31,6 +62,23 @@ class FeatureExtractor:
         the `Roi` input structure. All `Roi`s in the list of input data
         must have an ID (non null) otherwise this field will be ignored.
 
+        To add feature methods to this class, it is important to follow
+        the following convention:
+            1. Prefix feature name with "_feat"
+            2. Function signature must require only one positional
+               argument, of the following values:
+                   roi - a coo matrix, a single value of self.rois
+                   trace - 1d array-like, a single value of self.traces
+                   metadata - dict, a single value of self.metadata
+            Functions that require additional arguments should be
+            manually called during `run`, and not prefixed with `_feat`
+            so they are not automatically collected. The appropriate
+            arguments can be passed using instance attributes or
+            arguments to the `run` function. These should have defaults.
+        If this convention is not followed, the functions may not
+        be automatically collected/executed properly when calling
+        `FeatureExtractor.run`.
+
         Parameters
         ----------
         rois: Union[List[Roi], List[coo_matrix]]
@@ -42,7 +90,14 @@ class FeatureExtractor:
         metadata: List[RoiMetadata]
             A list of metadata dicts for each ROI in `rois`, with the
             schema described in `RoiMetadata`.
+        id_col: str, default="id"
+            Which column to use as as IDs for the ROI data (default="id").
+            If not present, will not record IDs.
 
+        spike_stddev_threshold: float, default=2.5
+            Used as input to _simple_n_spikes to compute the number of
+            spikes based on whether the data point in the trace exeeds
+            the value of `trace_stddev_threshold * std(trace)`.
         Raises
         ------
         ValueError
@@ -58,7 +113,7 @@ class FeatureExtractor:
         coo_rois = []
         if isinstance(rois[0], dict):    # Convert Roi data to coo_matrix
             for roi in rois:
-                id_ = roi.get("id")
+                id_ = roi.get(id_col)
                 if id_:
                     roi_ids.append(id_)
                 coo_rois.append(coo_matrix((roi["coo_data"],
@@ -73,6 +128,9 @@ class FeatureExtractor:
         self.dff_traces = dff_traces
         self.roi_ids = roi_ids
         self.metadata = pd.DataFrame.from_records(metadata)
+
+        # Feature-specific attributes
+        self.spike_stddev_threshold = spike_stddev_threshold
 
     @classmethod
     def from_list_of_dict(
@@ -97,7 +155,7 @@ class FeatureExtractor:
         return FeatureExtractor(rois=rois, dff_traces=traces, metadata=metas)
 
     @staticmethod
-    def _ellipticalness(roi: coo_matrix) -> float:
+    def _feat_ellipticalness(roi: coo_matrix) -> float:
         """
         Compute the 'ellipticalness' of a sparse matrix by dividing the
         length of the long axis by the length of the short axis.
@@ -120,7 +178,7 @@ class FeatureExtractor:
             return c_axis_len/r_axis_len
 
     @staticmethod
-    def _area(roi: coo_matrix) -> int:
+    def _feat_area(roi: coo_matrix) -> int:
         """
         Compute the 'area' of a sparse matrix by counting the number of
         nonzero pixels.
@@ -135,6 +193,9 @@ class FeatureExtractor:
             Total number of nonzero pixels of the matrix (the 'area')
         """
         return len(roi.data)
+
+    def _feat_simple_n_spikes(self, trace: np.ndarray) -> int:
+        return self._simple_n_spikes(trace, self.spike_stddev_threshold)
 
     @staticmethod
     def _simple_n_spikes(trace: np.ndarray,
@@ -157,8 +218,55 @@ class FeatureExtractor:
             Number of points where the data points exceeded the standard
             deviation threshold
         """
-        threshold = trace.std() * stddev_threshold
+        threshold = np.std(trace) * stddev_threshold
         return (trace > threshold).sum()
+
+    @staticmethod
+    def _feat_last_tenth_trace_skew(trace: np.ndarray):
+        """Compute the skew for the last tenth of the data.
+        This roughly corresponds to the 'fingerprint stimulus'
+        at the end."""
+        return skew(trace[-len(trace)//10:])
+
+    @staticmethod
+    def _feat_roi_width(roi: coo_matrix):
+        """Maximum size of the ROI along the x axis."""
+        return np.ptp(roi.col) + 1
+
+    @staticmethod
+    def _feat_roi_height(roi: coo_matrix):
+        """Maximum size of the ROI along the y axis."""
+        return np.ptp(roi.row) + 1
+
+    @staticmethod
+    def _feat_roi_data_std(roi: coo_matrix):
+        """Standard deviation of the weighted mask data."""
+        return np.std(roi.data)
+
+    @staticmethod
+    def _feat_roi_data_skew(roi: coo_matrix):
+        """Skew of the weighted mask data."""
+        return skew(roi.data)
+
+    @staticmethod
+    def _feat_neighborhood_info(roi: coo_matrix):
+        """Return information about neighbors. Since computing a kdtree
+        can be expensive, return all these features at once instead of
+        recomputing.
+
+        Returns a tuple of the following information (Computed for each
+        mask pixel and aggregated):
+            average distance to nearest neighbor
+            standard deviation of distance to nearest neighbor
+            skew of distance to nearest neighbor
+            average number of adjacent neighbors
+            standard deviation of number of adjacent neighbors
+            skew of number of adjacent neighbors
+        """
+        neighbor_extractor = NeighborhoodInfo(roi)
+        dist_tuple = neighbor_extractor.neighbor_dist(1)
+        adjacency_tuple = neighbor_extractor.adjacent_pixels()
+        return tuple([*dist_tuple, *adjacency_tuple])
 
     def run(self) -> pd.DataFrame:
         """
@@ -177,29 +285,98 @@ class FeatureExtractor:
         Returns
         -------
         pd.DataFrame:
-            A pandas dataframe with the following features:
-                'trace_skew': skew of trace
-                'roi_area': area of ROI mask
-                'roi_ellipticalness': 'ellipticalness' of ROI mask
-                'targeted_structure: targeted brain region
-                'rig': imaging rig name
-                'depth': imaging depth (of plane)
-                'full_genotype': CRE line of mouse
+            A pandas dataframe of extracted features. The columns of the
+            dataframe are the name of the functions (except for
+            values from `metadata` -- those are the keys), and are in
+            sorted order.
         """
-        trace_skew = list(map(skew, self.dff_traces))
-        roi_area = list(map(self._area, self.rois))
-        roi_ellipticalness = list(map(self._ellipticalness, self.rois))
+        feature_fns_dict = self._feat_fns_by_source(
+            self, sources=["roi", "trace"])
+        roi_data = self._apply_functions(
+            self.rois,
+            *[getattr(self, call) for call in feature_fns_dict["roi"]])
+        trace_data = self._apply_functions(
+            self.dff_traces,
+            *[getattr(self, call) for call in feature_fns_dict["trace"]])
         extracted_features = pd.DataFrame(
-            {
-                "trace_skew": trace_skew,
-                "roi_area": roi_area,
-                "roi_ellipticalness": roi_ellipticalness
-            }
-        )
+            list(tuple(chain.from_iterable(d))
+                 for d in zip(roi_data, trace_data)),
+            columns=feature_fns_dict["roi"] + feature_fns_dict["trace"])
+
+        # Add metadata
         features = pd.concat([extracted_features, self.metadata], axis=1)
+
+        # Take sorted columns so that ordering is deterministic
+        features = features[sorted(list(features))]
         if len(self.roi_ids):
             features.index = self.roi_ids
         return features
+
+    @staticmethod
+    def _feat_fns_by_source(obj: Any,
+                            sources: List = ["roi", "trace", "metadata"]):
+        """
+        This internal method is a helper function to get all the
+        functions prefixed with "_feat_" in this class (FeatureExtractor),
+        that also have one of the sources in `sources` as an argument.
+        The purpose of this is to allow for dynamically collecting
+        feature functions as they are added without having to call them
+        manually, and apply the appropriate data to them.
+
+        Note: This currently assumes that a feature function only uses
+        one source, and that the source is passed as a positional
+        argument.
+        Parameters
+        ----------
+        obj: Any
+            Technically any object but should be a class instance
+        sources: List
+            List of strings of data "sources". In this case we want to
+            separate out the functions that use the rois vs. traces vs.
+            metadata, etc. so that they can be properly called in
+            batches.
+        Returns
+        -------
+        dict
+            A dictionary of source to function name that uses that source
+            as an argument.
+            Example:
+                {"roi": ["_feat_roi_height", ...]
+                 "trace": [...]}
+        """
+        is_feat = partial(is_prefixed_function_or_method, prefix="_feat_")
+        feature_fns = inspect.getmembers(obj, is_feat)
+        fn_dict = dict(zip(sources, [[] for x in sources]))
+        for fn_name, fn in feature_fns:
+            args = inspect.getfullargspec(fn).args
+            for source in sources:
+                if source in args:
+                    fn_dict[source].append(fn_name)
+        return fn_dict
+
+    @staticmethod
+    def _apply_functions(xs: Iterable, *fns: Callable) -> List[tuple]:
+        """
+        Apply arbitrary number of functions to each element in an iterable,
+        and collect the results into a list of tuples (where each value
+        in the tuple is the result of applying one of the functions in
+        `fns` to the element in `xs`.)
+        Parameters
+        ----------
+        xs: Iterable
+            An iterable of input data, such as a numpy array
+        fns: Callable
+            Functions to apply to each member in the iterable `xs`.
+            Should take a single argument and return a single value.
+        Returns
+        -------
+        List of tuples; values of the tuples are from applying each
+        function in `fns` to each element in the iterable `xs`.
+        """
+        records = []
+        for y in xs:
+            records.append(tuple((fn(y) for fn in fns)))
+        return records
 
 
 def feature_pipeline() -> Pipeline:

--- a/croissant/utils.py
+++ b/croissant/utils.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from pathlib import Path
 import jsonlines
 import json
+import inspect
 from botocore.exceptions import ClientError
 
 
@@ -133,3 +134,17 @@ def object_exists(bucket, key):
     except ClientError:
         pass
     return exists
+
+
+def is_prefixed_function_or_method(obj: Any, prefix: str = ""):
+    """
+    Returns true if the object is a method/function and the name
+    of the object starts with `prefix`, otherwise returns False.
+    """
+    try:
+        if ((inspect.ismethod(obj) or inspect.isfunction(obj)) and
+                obj.__name__.startswith(prefix)):
+            return True
+    except AttributeError:
+        pass
+    return False

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -21,8 +21,8 @@ def basic_data():
             [1, 1, 1], [2, 2, 2],
         ],
         [   # metadata
-            {"genotype": "you", "rig": "up"},
-            {"rig": "down", "genotype": "you"},
+            {"genotype": "you"},
+            {"genotype": "you"},
         ]
     )
 
@@ -148,7 +148,7 @@ def test_roi_width(roi, expected):
     ]
 )
 def test_neighborhood_info(roi, expected):
-    actual = fx._feat_neighborhood_info(roi)
+    actual = fx._neighborhood_info(roi)
     for ix, val in enumerate(expected):
         assert val == actual[ix]
 
@@ -291,9 +291,10 @@ def test_feat_fns_by_source(sources, expected, function_class):
 @pytest.mark.parametrize(
     "xs, fns, expected",
     [
-        ([1], (lambda x: 3,), [(3,)],),
+        ([1], (lambda x: "3a",), [("3a",)],),
         ([], (lambda x: 1,), [],),
-        ([1, 2, 3], (lambda x: x*2, lambda x: x), [(2, 1), (4, 2), (6, 3)],),
+        ([1, 2, 3], (lambda x: (x*2, 1), lambda x: x),
+         [(2, 1, 1), (4, 1, 2), (6, 1, 3)],),
     ]
 )
 def test_apply_fns(xs, fns, expected):
@@ -330,6 +331,9 @@ def test_feature_extractor_run(MockFeatureExtractor, monkeypatch, basic_data):
         mock_fx, "_feat_fns_by_source",
         lambda *args, **kwargs: {"roi": ["_testfeat_roi1", "_testfeat_roi2"],
                                  "trace": ["_testfeat_trace"]})
+    monkeypatch.setattr(
+        mock_fx, "_run_special_features",
+        lambda: pd.DataFrame({"rig": ["up", "down"]}))
     expected = pd.DataFrame(
         [["never", "gonna", "give", "you", "up"],
          ["never", "gonna", "let", "you", "down"]],

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -1,8 +1,67 @@
 import pytest
 import numpy as np
 from scipy.sparse import coo_matrix
+from scipy.stats import skew
+from typing import Any
+import pandas as pd
 
 from croissant.features import FeatureExtractor as fx
+
+
+@pytest.fixture
+def basic_data():
+    return (
+        [   # rois
+            {"id": 867, "coo_rows": [0], "coo_cols": [1],
+                "coo_data": [1], "image_shape": (2, 3)},
+            {"id": 5309, "coo_rows": [1], "coo_cols": [0],
+                "coo_data": [1], "image_shape": (2, 3)},
+        ],
+        [   # traces
+            [1, 1, 1], [2, 2, 2],
+        ],
+        [   # metadata
+            {"genotype": "you", "rig": "up"},
+            {"rig": "down", "genotype": "you"},
+        ]
+    )
+
+
+@pytest.fixture
+def function_class():
+    """Test fixture for _feat_fns_by_source"""
+    class FunctionClass():
+        def __init__(self):
+            pass
+
+        def _feat_fn_arg(self, arg: Any):
+            pass
+
+        @classmethod
+        def _feat_cls_fn_arg(cls, arg: Any):
+            pass
+
+        @staticmethod
+        def _feat_static_fn_arg(arg: Any):
+            pass
+
+        def _feat_multi_arg(self, arg: Any, arg1: Any, *, arg2: Any = None):
+            pass
+
+        @staticmethod
+        def _feat_no_arg():
+            pass
+
+        def _feat_different_arg(self, arg1: Any = None):
+            pass
+
+        def _feat_no_arg_self(self):
+            pass
+
+        def non_feat_arg(self, arg: Any):
+            pass
+
+    return FunctionClass
 
 
 @pytest.mark.parametrize(
@@ -18,7 +77,7 @@ from croissant.features import FeatureExtractor as fx
     ]
 )
 def test_ellipticalness(roi, expected):
-    assert fx._ellipticalness(roi) == expected
+    assert fx._feat_ellipticalness(roi) == expected
 
 
 @pytest.mark.parametrize(
@@ -31,7 +90,67 @@ def test_ellipticalness(roi, expected):
     ],
 )
 def test_area(roi, expected):
-    assert fx._area(roi) == expected
+    assert fx._feat_area(roi) == expected
+
+
+@pytest.mark.parametrize(
+    "trace, expected",
+    [
+        (np.ones((10,)), 0),
+        (np.arange(11), 0)      # Skew wouldn't be zero if length incorrect
+    ]
+)
+def test_last_tenth_trace_skew(trace, expected):
+    assert expected == fx._feat_last_tenth_trace_skew(trace)
+
+
+@pytest.mark.parametrize(
+    "roi, expected",
+    [
+        (coo_matrix(np.ones((3, 6))), 3),
+        (coo_matrix(np.ones((5,))), 1),
+    ]
+
+)
+def test_roi_height(roi, expected):
+    assert expected == fx._feat_roi_height(roi)
+
+
+@pytest.mark.parametrize(
+    "roi, expected",
+    [
+        (coo_matrix(np.ones((3, 6))), 6),
+        (coo_matrix(np.ones((5,))), 5),
+    ]
+
+)
+def test_roi_width(roi, expected):
+    assert expected == fx._feat_roi_width(roi)
+
+
+@pytest.mark.parametrize(
+    "roi, expected",
+    [
+        (
+            coo_matrix(np.ones((3, 3))),
+            (
+                1, 0, 0,        # all of them have closest neighbor at r=1
+                ((4*3) +        # 4 corners with 3 neighbors
+                 (1*8) +        # central point with 8 neighbors
+                 (4*5))/9,      # 4 middles with 5 neighbors
+                np.std([3, 3, 3, 3, 8, 5, 5, 5, 5]),
+                skew([3, 3, 3, 3, 8, 5, 5, 5, 5])
+            ),
+        ),
+        (
+            coo_matrix(([1], ([2], [2])), shape=(3, 3)), (0, 0, 0, 0, 0, 0)
+        )
+    ]
+)
+def test_neighborhood_info(roi, expected):
+    actual = fx._feat_neighborhood_info(roi)
+    for ix, val in enumerate(expected):
+        assert val == actual[ix]
 
 
 @pytest.mark.parametrize(
@@ -135,3 +254,88 @@ def test_FeatureExtractor_nonequal_input_error(rois, traces, metadata):
     """Test unequal input lengths raise error."""
     with pytest.raises(ValueError):
         fx(rois, traces, metadata)
+
+
+@pytest.mark.parametrize(
+    "sources, expected",
+    [
+        (
+            ["arg"],
+            {
+                "arg": ["_feat_fn_arg", "_feat_cls_fn_arg",
+                        "_feat_static_fn_arg", "_feat_multi_arg"]
+            }
+        ),
+        (
+            ["arg", "arg1", "arg2"],
+            {
+                "arg": ["_feat_fn_arg", "_feat_cls_fn_arg",
+                        "_feat_static_fn_arg", "_feat_multi_arg"],
+                "arg1": ["_feat_different_arg", "_feat_multi_arg"],
+                "arg2": []
+            }
+        )
+    ]
+)
+def test_feat_fns_by_source(sources, expected, function_class):
+    my_class = function_class()
+    actual = fx._feat_fns_by_source(my_class, sources=sources)
+    # Pytest doesn't have nice stuff for dicts... much less dicts with lists
+    for k, vals in expected.items():
+        assert k in actual
+        assert len(actual[k]) == len(vals)
+        for v in vals:
+            assert v in actual[k]
+
+
+@pytest.mark.parametrize(
+    "xs, fns, expected",
+    [
+        ([1], (lambda x: 3,), [(3,)],),
+        ([], (lambda x: 1,), [],),
+        ([1, 2, 3], (lambda x: x*2, lambda x: x), [(2, 1), (4, 2), (6, 3)],),
+    ]
+)
+def test_apply_fns(xs, fns, expected):
+    assert expected == fx._apply_functions(xs, *fns)
+
+
+@pytest.fixture
+def MockFeatureExtractor():
+    class MockFeatureExtractor(fx):
+        def __init__(self, *args):
+            super().__init__(*args)
+
+        @staticmethod
+        def _testfeat_trace(trace):
+            if trace[0] % 2 == 0:
+                return "let"
+            else:
+                return "give"
+
+        @staticmethod
+        def _testfeat_roi1(roi):
+            return "never"
+
+        def _testfeat_roi2(self, roi):
+            return "gonna"
+
+    return MockFeatureExtractor
+
+
+def test_feature_extractor_run(MockFeatureExtractor, monkeypatch, basic_data):
+    mock_fx = MockFeatureExtractor(*basic_data)
+    # Get the subset of functions defined in the mock class instead
+    monkeypatch.setattr(
+        mock_fx, "_feat_fns_by_source",
+        lambda *args, **kwargs: {"roi": ["_testfeat_roi1", "_testfeat_roi2"],
+                                 "trace": ["_testfeat_trace"]})
+    expected = pd.DataFrame(
+        [["never", "gonna", "give", "you", "up"],
+         ["never", "gonna", "let", "you", "down"]],
+        columns=["_testfeat_roi1", "_testfeat_roi2", "_testfeat_trace",
+                 "genotype", "rig"],
+        index=[867, 5309]
+    )
+    actual = mock_fx.run()
+    pd.testing.assert_frame_equal(expected, actual)


### PR DESCRIPTION
Resolves #41 and #53 

Adds most of the additional features from feature exploration notebook. I did not include the spike extraction methods since I think those might be a little controversial. We can include them in the next batch if desired, especially once we get neuropil-subtracted traces.

I didn't write tests for the reskins of numpy/scipy functions or simple python calls, since I thought that would be a little excessive. Looking at you `_feat_roi_area`.

I am working on retraining the model so I can close out 53 as well, but I have not done it yet. Please feel free to review the code in the meantime. @njmei I might ask for your help to re-run the LIMS pipeline because I don't have the local build currently set up.