### PR TITLE
adds ability to specify image from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,13 @@ python -m croissant.online_training \
 ```
 
 Once launched, these tasks can be tracked n the AWS console `ECS -> Cluster -> Tasks` where the cluster name is based on the cloudformation stack name. For example `mlflow-test-stack-fargate-cluster `. The logs of the job can be found from `Cloudwatch -> Logs -> LogGroups` and the log group will also be named based on the stack name, for example `mlflow-test-stack-ecs `.
+
+The container image that is run above is specified at cloudformation stack creation time, or via a stack deployment changeset application. We can also dynamically supply a container image on the command line. This can be helpful for quicker development iteration. In this case, a new task definition for ECS will be created and run, rather than the existing stack-defined task defintion. The additional argument is `container_image`:
+```
+python -m croissant.online_training \
+  --output_json ./output.json \
+  --training_args.training_data s3://prod.slapp.alleninstitute.org/merged_2line_2project/training_data.json \
+  --training_args.test_data s3://prod.slapp.alleninstitute.org/merged_2line_2project/testing_data.json \
+  --training_args.log_level INFO \
+  --container_image docker.io/alleninstitutepika/croissant:7ca6c6968866ad1b545df5c8dc92544809864413
+```


### PR DESCRIPTION
Same steps as covered in the README for online training, except an additional optional arg:
```
python -m croissant.online_training  \
    --output_json <path to output json> \
    --training_args.training_data <s3 URI for training data> \
    --training_args.test_data <s3 URI for test data>\
    --training_args.log_level INFO \
    --container_image docker.io/alleninstitutepika/croissant:7ca6c6968866ad1b545df5c8dc92544809864413
```

A successful cloudwatch log from using this feature:
![image](https://user-images.githubusercontent.com/32312979/90299397-ca3a8380-de4a-11ea-93af-1e5565ce6f92.png)

A successful mlflow entry from the same run. Note the commit hash matches the specified docker tag:
![image](https://user-images.githubusercontent.com/32312979/90299447-f5bd6e00-de4a-11ea-8aed-8627a811823a.png)
