### PR TITLE
Update train methods

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -17,3 +17,4 @@ dependencies:
       - hyperopt
       - hpsklearn
       - scikit-image
+      - h5py

--- a/croissant/roi.py
+++ b/croissant/roi.py
@@ -102,14 +102,13 @@ class LimsRoiSchema(Schema):
         description=("Boolean indicating if the ROI is a valid "
                      "cell or not"))
     mask_matrix = fields.List(
-        fields.List(fields.Bool), 
+        fields.List(fields.Bool),
         required=True,
         description=("Bool nested list describing which pixels "
                      "in the ROI area are part of the cell"))
     max_correction_up = fields.Float(
         required=True,
-        description=("Max correction in pixels in the "
-                                           "up direction"))
+        description=("Max correction in pixels in the up direction"))
     max_correction_down = fields.Float(
         required=True,
         description=("Max correction in pixels in the "
@@ -120,8 +119,7 @@ class LimsRoiSchema(Schema):
                      "left direction"))
     max_correction_right = fields.Float(
         required=True,
-        description="Max correction in the pixels in "
-                                             "the right direction")
+        description="Max correction in the pixels in the right direction")
     mask_image_plane = fields.Int(
         required=True,
         description=("The old segmentation pipeline stored "
@@ -131,7 +129,7 @@ class LimsRoiSchema(Schema):
                      "always be set to zero for the new "
                      "updated pipeline"))
     exclusion_labels = fields.List(
-        fields.Str, 
+        fields.Str,
         required=True,
         description=("LIMS ExclusionLabel names used to "
                      "track why a given ROI is not "

--- a/croissant/roi.py
+++ b/croissant/roi.py
@@ -1,11 +1,16 @@
 from __future__ import annotations  # noqa
 import sys
 from typing import Optional, List, Tuple
+import warnings
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict
+
+from marshmallow import Schema, fields, exceptions, post_load
+import numpy as np
+from scipy.sparse import coo_matrix
 
 
 class Roi(TypedDict):
@@ -69,3 +74,99 @@ class RoiWithMetadata():
                 targeted_structure=d['targeted_structure'],
                 rig=d['rig'])
         return RoiWithMetadata(roi, roi_meta, d['trace'], d['label'])
+
+
+class LimsRoiSchema(Schema):
+    """This ROI format is the expected output of Segmentation/Binarization.
+    Copied from ophys_etl to avoid circular dependency (I know...)
+    """
+
+    id = fields.Int(
+        required=True,
+        description=("Unique ID of the ROI, get's overwritten writting "
+                     "to LIMS"))
+    x = fields.Int(
+        required=True,
+        description="X location of top left corner of ROI in pixels")
+    y = fields.Int(
+        required=True,
+        description="Y location of top left corner of ROI in pixels")
+    width = fields.Int(
+        required=True,
+        description="Width of the ROI in pixels")
+    height = fields.Int(
+        required=True,
+        description="Height of the ROI in pixels")
+    valid_roi = fields.Bool(
+        required=True,
+        description=("Boolean indicating if the ROI is a valid "
+                     "cell or not"))
+    mask_matrix = fields.List(
+        fields.List(fields.Bool), 
+        required=True,
+        description=("Bool nested list describing which pixels "
+                     "in the ROI area are part of the cell"))
+    max_correction_up = fields.Float(
+        required=True,
+        description=("Max correction in pixels in the "
+                                           "up direction"))
+    max_correction_down = fields.Float(
+        required=True,
+        description=("Max correction in pixels in the "
+                     "down direction"))
+    max_correction_left = fields.Float(
+        required=True,
+        description=("Max correction in pixels in the "
+                     "left direction"))
+    max_correction_right = fields.Float(
+        required=True,
+        description="Max correction in the pixels in "
+                                             "the right direction")
+    mask_image_plane = fields.Int(
+        required=True,
+        description=("The old segmentation pipeline stored "
+                     "overlapping ROIs on separate image "
+                     "planes. For compatibility purposes, "
+                     "this field must be kept, but will "
+                     "always be set to zero for the new "
+                     "updated pipeline"))
+    exclusion_labels = fields.List(
+        fields.Str, 
+        required=True,
+        description=("LIMS ExclusionLabel names used to "
+                     "track why a given ROI is not "
+                     "considered a valid_roi. (examples: "
+                     "motion_border, "
+                     "classified_as_not_cell)"))
+
+    @post_load
+    def add_coo_data(self, data, **kwargs):
+        """Convert ROIs to coo format, which is used by the croissant
+        FeatureExtractor. Input includes 'x' and 'y' fields
+        which designate the cartesian coordinates of the top right corner,
+        the width and height of the bounding box, and boolean values for
+        whether the mask pixel is contained. The returned coo_matrix
+        will contain all the data in the mask in the proper shape,
+        but essentially discards the 'x' and 'y' information (the
+        cartesian position of the masks is not important for the
+        below methods). Represented as a dense array, the mask data
+        would be "cropped" to the bounding box.
+        Note: If the methods were updated such that the position of
+        the mask relative to the input data *were*
+        important (say, if necessary to align the masks to the movie
+        from which they were created), then this function would require
+        the dimensions of the source movie.
+        """
+        shape = (data["height"], data["width"])
+        arr = np.array(data["mask_matrix"]).astype("int")
+        if data["height"] + data["width"] == 0:
+            warnings.warn("Input data contains empty ROI. "
+                          "This may cause problems.")
+        elif arr.shape != shape:
+            raise exceptions.ValidationError(
+                "Data in mask matrix did not correspond to "
+                "the (height, width) dimensions. Please "
+                "check the input data.")
+        mat = coo_matrix(arr)
+        data.update({"coo_roi": mat})
+        return data

--- a/croissant/scripts/annotation_ingest.py
+++ b/croissant/scripts/annotation_ingest.py
@@ -322,8 +322,8 @@ class AnnotationIngestJob(argschema.ArgSchemaParser):
         train, test = train_test_split(
             annotations, test_size=self.args["test_split"], shuffle=True)
         # Save s3 or local storage
-        json_write_local_or_s3(train.to_json(orient="records"), train_path)
-        json_write_local_or_s3(test.to_json(orient="records"), test_path)
+        json_write_local_or_s3(train.to_dict(orient="records"), train_path)
+        json_write_local_or_s3(test.to_dict(orient="records"), test_path)
 
         self.logger.info(f"Wrote data to {train_path} and {test_path}.")
         self.output({

--- a/croissant/scripts/annotation_ingest.py
+++ b/croissant/scripts/annotation_ingest.py
@@ -151,10 +151,11 @@ class AnnotationIngestJobInput(argschema.ArgSchema):
     # annotations_key = argschema.fields.Str(
     #     required=False,
     #     default=None,
-    #     description=("If applicable, the key in the record that contains the "
-    #                  "list of individual worker annotations (as dict records)."
-    #                  " Used to provide additional descriptive statistics "
-    #                  "about worker decisions."))
+    #     description=(
+    #       "If applicable, the key in the record that contains the "
+    #       "list of individual worker annotations (as dict records)."
+    #       " Used to provide additional descriptive statistics "
+    #       "about worker decisions."))
     label_map = argschema.fields.Dict(
         required=False,
         missing=None,

--- a/croissant/scripts/annotation_ingest.py
+++ b/croissant/scripts/annotation_ingest.py
@@ -1,0 +1,339 @@
+import os.path
+import json
+from typing import List, Union
+from pathlib import Path
+import warnings
+import time
+
+import argschema
+import marshmallow as mm
+import pandas as pd
+import lims.query_utils as qu
+import h5py
+from sklearn.model_selection import train_test_split
+
+from croissant.ingest import annotation_df_from_file
+from croissant.roi import LimsRoiSchema
+from croissant.utils import (
+    _munge_traces, json_write_local_or_s3, path_join_s3_os)
+
+
+class SlappUploadManifest(mm.Schema):
+    class Meta:
+        unknown = mm.EXCLUDE
+
+    experiment_id = mm.fields.Integer(
+        required=True,
+        description="Global experiment ID used by LIMS."
+    )
+    binarized_rois_path = argschema.fields.InputFile(
+        required=True,
+        description="Path to binarized ROIs output json on accessible FS."
+    )
+    traces_h5_path = mm.fields.Str(
+        required=True,
+        description="Path to raw trace file on accessible FS.",
+        validate=os.path.exists
+    )
+    local_to_global_roi_id_map = mm.fields.Dict(
+        keys=mm.fields.Str,
+        values=mm.fields.Int,
+        required=True
+    )
+    movie_path = mm.fields.Str(
+        required=True,
+        description="Path to raw movie file on accessible FS."
+    )
+
+
+class AnnotationIngestJobOutput(argschema.ArgSchema):
+    train_data_path = mm.fields.Str(
+        required=True,
+        description="Local path or S3 URI to training data."
+    )
+    test_data_path = mm.fields.Str(
+        required=True,
+        description="Local path or S3 URI to test data."
+    )
+    created_at = mm.fields.Int(
+        required=True,
+        description="Seconds since epoch the files were created."
+    )
+    total_annotations = mm.fields.Int(
+        required=True,
+        description="Total number of annotations."
+    )
+    missing_data = mm.fields.List(
+        mm.fields.Int,
+        required=True,
+        default=[],
+        description="List of experiment_ids with missing upload manifests."
+    )
+    # TODO
+    # label_summary = mm.fields.Dict(
+    #     required=False,
+    #     description="Metadata about annotations."
+    # )
+
+
+class AnnotationIngestJobInput(argschema.ArgSchema):
+    """
+    The results from loading in the manifests will be made available
+    in the argschema parser args via the key "manifest_data".
+    """
+    slapp_upload_manifest_path = argschema.fields.InputFile(
+        required=False,
+        default=None,
+        missing=None,
+        description=("Path to the manifest file used to upload data "
+                     "for SLAPP annotation tool. If missing will crawl "
+                     "directories in data_root_dir looking for upload "
+                     "manifests."))
+    data_root_dir = argschema.fields.InputDir(
+        required=False,
+        missing=None,
+        default=None,
+        description=("Path to the root directory to search for individual "
+                     "manifest files named `manifest_stub`. Used if "
+                     "`slapp_upload_manifest_path` not provided.")
+    )
+    manifest_stub = argschema.fields.Str(
+        required=False,
+        default="slapp_tform_manifest.json",
+        missing="slapp_tform_manifest.json",
+        description=("Filename for the transform manifest per experiment. "
+                     "Only used if `data_root_dir` is provided, and "
+                     "slapp_upload_manifest_path isn't.")
+    )
+    output_location = argschema.fields.Str(
+        required=True,
+        description=("Path to a directory for saving the training data "
+                     "on local file system, or an s3 URI for cloud blob "
+                     "storage.")
+    )
+    test_split = argschema.fields.Float(
+        required=False,
+        missing=None,
+        default=None,
+        description=("Percent split for test data. Must be betweeen "
+                     "0 and 1 (exclusive). Test data will be saved "
+                     "in the `output_location` as train.json, and test "
+                     "data will be saved as test.json."),
+        validate=lambda x: ((x > 0.) and (x < 1.))
+    )
+    annotation_output_manifest = argschema.fields.Str(
+        required=True,
+        description=("S3 URI to the output directory containing annotations "
+                     "from Sagemaker GT job."))
+    labeling_project_key = argschema.fields.Str(
+        required=True,
+        description=("Name of this particular Sagemaker GT labeling job."))
+    annotation_id_key = argschema.fields.Str(
+        required=False,
+        default="roi-id",
+        missing="roi-id",
+        description=("Key to use as index for annotation records in the "
+                     "output manifest. Should be a top level key in record."))
+    annotation_experiment_id_key = argschema.fields.Str(
+        required=False,
+        default="experiment-id",
+        missing="experiment-id",
+        description=("Key to use as index for annotation records in the "
+                     "output manifest. Should be a top level key in record."))
+    label_key = argschema.fields.Str(
+        required=False,
+        default="majorityLabel",
+        missing="majorityLabel",
+        description=("Key that contains the final labeled value to extract, "
+                     "in the object (dict) indexed by `labeling_project_key` "
+                     "in the output manifest."))
+    # TODO
+    # annotations_key = argschema.fields.Str(
+    #     required=False,
+    #     default=None,
+    #     description=("If applicable, the key in the record that contains the "
+    #                  "list of individual worker annotations (as dict records)."
+    #                  " Used to provide additional descriptive statistics "
+    #                  "about worker decisions."))
+    label_map = argschema.fields.Dict(
+        required=False,
+        missing=None,
+        default=None,
+        description=("Map to apply to the labels. If no map provided, the "
+                     "the raw values will be extracted from the manifest. "
+                     "This can be skipped if the class labels are already "
+                     "numeric (e.g. 0, 1...)"))
+
+    @mm.post_load
+    def make_objects(self, data, **kwargs):
+        if data["slapp_upload_manifest_path"]:
+            with open(data["slapp_upload_manifest_path"], "r") as f:
+                upload_manifest_data = json.load(f)
+            upload_manifest_obj = SlappUploadManifest().load(
+                upload_manifest_data)
+            data["manifest_data"] = [upload_manifest_obj]
+        return data
+
+
+class AnnotationIngestJob(argschema.ArgSchemaParser):
+    default_schema = AnnotationIngestJobInput
+    default_output_schema = AnnotationIngestJobOutput
+
+    @staticmethod
+    def compile_manifests(
+            exp_ids: List[int], data_root_dir: Union[str, Path],
+            manifest_stub: str):
+        missing_data = []
+        manifests = []
+        if isinstance(data_root_dir, str):
+            data_root_dir = Path(data_root_dir)
+        for id_ in exp_ids:
+            subdir = data_root_dir / f"{id_}"
+            if os.path.exists(subdir / manifest_stub):
+                with open(subdir / manifest_stub, "r") as f:
+                    manifest_data = json.load(f)
+                    manifest_obj = SlappUploadManifest().load(manifest_data)
+                    manifests.append(manifest_obj)
+            else:
+                missing_data.append(id_)
+        if missing_data:
+            warnings.warn(f"Missing data for {len(missing_data)} ids: \n"
+                          f"{missing_data}")
+        return manifests, missing_data
+
+    @staticmethod
+    def get_metadata(exp_ids: List[int]):
+        """This will only work when run on AIBS local network."""
+        creds = qu.get_db_credentials()
+        conn = qu.DbConnection(**creds)
+        # Build array selector for IDs in query
+        id_arr = ", ".join(map(str, exp_ids))
+        results = conn.query(
+            f"""
+            SELECT
+                movie_frame_rate_hz,
+                e.name AS rig,
+                d.full_genotype,
+                st.acronym AS targeted_structure,
+                i.depth,
+                oe.id AS experiment_id
+            FROM ophys_experiments oe
+            JOIN ophys_sessions os ON oe.ophys_session_id = os.id
+            JOIN equipment e ON os.equipment_id = e.id
+            JOIN specimens sp ON os.specimen_id = sp.id
+            JOIN donors d ON sp.donor_id = d.id
+            JOIN imaging_depths i ON i.id=oe.imaging_depth_id
+            JOIN structures st ON st.id=oe.targeted_structure_id
+            WHERE oe.id IN ({id_arr})""")
+        return results
+
+    def main(self):
+        self.logger.name = type(self).__name__
+        self.logger.setLevel(self.args.pop("log_level"))
+        additional_keys = [
+            (self.args["annotation_id_key"], ),
+            (self.args["annotation_experiment_id_key"], )]
+
+        # Pull annotations from s3 or file system, and set global ID index
+        annotations = annotation_df_from_file(
+            self.args["annotation_output_manifest"],
+            self.args["labeling_project_key"],
+            self.args["label_key"],
+            additional_keys=additional_keys)
+        self.logger.info(
+            "Annotations successfully ingested from output manifest "
+            f"(n={len(annotations)}).")
+        if self.args["label_map"]:
+            annotations["label"] = annotations[self.args["label_key"]].map(
+                self.args["label_map"])
+        else:
+            annotations["label"] = annotations[self.args["label_key"]].copy()
+        # Format correctly
+        annotations.set_index(self.args["annotation_id_key"], inplace=True)
+        annotations.rename(
+            {self.args["annotation_experiment_id_key"]: "experiment_id"},
+            axis=1, inplace=True)
+        exp_ids = list(set(annotations["experiment_id"]))
+
+        # If an explicit manifest hasn't been passed, find all by looking
+        # in subdirectories named for experiment_ids
+        if not self.args.get("manifest_data"):
+            self.args["manifest_data"], missing_data = self.compile_manifests(
+                exp_ids,
+                self.args["data_root_dir"],
+                self.args["manifest_stub"])
+
+        # Pull metadata from db
+        # Contains rig, movie frame rate, targeted structure, genotype, depth
+        self.logger.info("Retrieving metadata from LIMS database.")
+        metadata = (pd.DataFrame(self.get_metadata(exp_ids))
+                    .set_index("experiment_id"))
+
+        # Load the data required
+        # movie shape (for coo matrix rehydration)
+        self.logger.info("Loading raw data files.")
+        roi_raw_data = []
+        for manifest in self.args["manifest_data"]:
+            with h5py.File(manifest["movie_path"], "r") as f:
+                image_shape = f["data"].shape[1:]
+            with open(manifest["binarized_rois_path"], "r") as f:
+                rois = json.load(f)
+            local_ids = [i["id"] for i in rois]
+            # roi coo matrix
+            for local_id, global_id in (
+                    manifest["local_to_global_roi_id_map"].items()):
+                local_roi = LimsRoiSchema().load(
+                    rois[local_ids.index(int(local_id))])
+                # trace (downsampled)
+                trace = _munge_traces(
+                        [local_roi],
+                        trace_file_path=manifest['traces_h5_path'],
+                        trace_data_key='data',
+                        trace_names_key='roi_names',
+                        trace_sampling_rate=int(
+                            metadata.loc[manifest["experiment_id"]]
+                            ["movie_frame_rate_hz"]),
+                        desired_trace_sampling_rate=4)[0]
+                roi_raw_data.append({
+                    "roi_id": global_id,
+                    "coo_rows": local_roi["coo_roi"].row.tolist(),
+                    "coo_cols": local_roi["coo_roi"].col.tolist(),
+                    "coo_data": local_roi["coo_roi"].data.tolist(),
+                    "image_shape": image_shape,
+                    "trace": trace.tolist()})
+
+        self.logger.info("Raw data loaded. Formatting data.")
+        # Get things joined up and in the right format
+        roi_dataframe = pd.DataFrame(roi_raw_data).set_index("roi_id")
+        annotations = annotations.join(roi_dataframe, how="inner")
+        annotations = annotations.join(
+            metadata, on="experiment_id", how="inner")
+        # For RoiWithMetadata
+        annotations.drop(["movie_frame_rate_hz", "majorityLabel"],
+                         axis=1, inplace=True)
+        annotations["roi_id"] = annotations.index
+        annotations.reset_index(drop=True, inplace=True)
+
+        train_path = path_join_s3_os(
+            self.args["output_location"], "train.json")
+        test_path = path_join_s3_os(self.args["output_location"], "test.json")
+
+        train, test = train_test_split(
+            annotations, test_size=self.args["test_split"], shuffle=True)
+        # Save s3 or local storage
+        json_write_local_or_s3(train.to_json(orient="records"), train_path)
+        json_write_local_or_s3(test.to_json(orient="records"), test_path)
+
+        self.logger.info(f"Wrote data to {train_path} and {test_path}.")
+        self.output({
+            "train_data_path": train_path,
+            "test_data_path": test_path,
+            "created_at": int(time.time()),
+            "total_annotations": len(annotations),
+            "missing_data": missing_data
+        })
+
+
+if __name__ == "__main__":
+    job = AnnotationIngestJob()
+    job.main()

--- a/croissant/utils.py
+++ b/croissant/utils.py
@@ -1,5 +1,5 @@
 """Miscellaneous utility functions that don't quite belong elsewhere."""
-from typing import Any, Union, Generator
+from typing import Any, Union, Generator, List
 from functools import reduce
 import operator
 import boto3
@@ -9,6 +9,14 @@ import jsonlines
 import json
 import inspect
 from botocore.exceptions import ClientError
+import numpy as np
+import h5py
+import math
+from scipy.signal import resample_poly
+import io
+import os.path
+
+from croissant.roi import LimsRoiSchema
 
 
 def read_jsonlines(uri: Union[str, Path]) -> Generator[dict, None, None]:
@@ -92,6 +100,55 @@ def json_load_local_or_s3(uri: str) -> dict:
     return jobj
 
 
+def json_write_local_or_s3(obj, uri: str):
+    """Write a json to local storage or S3 path.
+
+    Parameters
+    ----------
+    obj:
+        Any json-writable object (compatible with `json.dump`).
+    uri: str
+        An S3 URI or path to local file system.
+    """
+    if uri.startswith("s3://"):
+        parsed_s3 = urlparse(uri)
+        bucket = parsed_s3.netloc
+        file_key = parsed_s3.path[1:]
+        s3 = boto3.client('s3')
+        with io.BytesIO() as f:
+            f.write(json.dumps(obj).encode())
+            f.seek(0)
+            s3.upload_fileobj(f, bucket, file_key)
+    else:
+        with open(uri, "w") as f:
+            json.dump(obj, f)
+
+
+def path_join_s3_os(path: str, to_join: str) -> str:
+    """Analogous to os.path.join that works regardless of for s3 
+    or file system. The format doesn't matter for Unix machines since
+    both the web and file system use '/', but does matter for Windows
+    since paths use '\'.
+    
+    Parameters
+    ----------
+    path: str
+        The base path
+    to_join: str
+        A string to join to the end of the base path with a system-
+        appropriate character.
+
+    Returns
+    -------
+    str
+        The joined path.
+    """
+    if path.startswith("s3://"):
+        return f"{path}/{to_join}"
+    else:
+        return os.path.join(path, to_join)
+
+
 def s3_get_object(uri: str) -> dict:
     """
     Utility wrapper for calling get_object from the boto3 s3 client,
@@ -148,3 +205,78 @@ def is_prefixed_function_or_method(obj: Any, prefix: str = ""):
     except AttributeError:
         pass
     return False
+
+
+def _munge_traces(roi_data: List[LimsRoiSchema], trace_file_path: str,
+                  trace_data_key: str, trace_names_key: str,
+                  trace_sampling_rate: int, desired_trace_sampling_rate: int
+                  ) -> List[np.ndarray]:
+    """Read trace data from h5 file (in proper order) and downsample it.
+    Parameters
+    ----------
+    roi_data : List[SparseAndDenseROI]
+        A list of ROIs that conform to the SparseAndDenseROISchema.
+    trace_file_path : str
+        Path to h5 file containing trace data.
+    trace_data_key : str
+        Key used to access trace data.
+    trace_names_key : str
+        Key used to access the ROI name (id) corresponding to each trace.
+    trace_sampling_rate : int
+        Sampling rate (in Hz) of trace data.
+    desired_trace_sampling_rate : int
+        Desired sampling rate (in Hz) that trace data should be
+        downsampled to.
+    Returns
+    -------
+    List[np.1darray]
+        A list of downsampled traces with each element corresponding to
+        an element in roi_data.
+    """
+    traces_file = h5py.File(trace_file_path, "r")
+    traces_data = traces_file[trace_data_key]
+
+    # An array of str(int) describing roi names (id) associated with each trace
+    # Example: ['10', '100', ..., '2', '20', '200', ..., '3']
+    traces_id_order = traces_file[trace_names_key][:].astype(int)
+    traces_id_mapping = {val: ind for ind, val in enumerate(traces_id_order)}
+
+    downsampled_traces = []
+    for roi in roi_data:
+        assert roi['id'] == traces_id_order[traces_id_mapping[roi['id']]]
+        trace_indx = traces_id_mapping[roi["id"]]
+        ds_trace = downsample(traces_data[trace_indx, :],
+                              trace_sampling_rate,
+                              desired_trace_sampling_rate)
+        downsampled_traces.append(ds_trace)
+
+    traces_file.close()
+    return downsampled_traces
+
+
+def downsample(trace: np.ndarray, input_fps: int, output_fps: int):
+    """Downsample 1d array using scipy resample_poly.
+    See https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.resample_poly.html#scipy.signal.resample_poly    # noqa
+    for more information.
+    Parameters
+    ----------
+    trace: np.ndarray
+        1d array of values to downsample
+    input_fps: int
+        The FPS that the trace data was captured at
+    output_fps: int
+        The desired FPS of the trace
+    Returns
+    -------
+    np.ndarray
+        1d array of values, downsampled to output_fps
+    """
+    if input_fps == output_fps:
+        return trace
+    elif output_fps > input_fps:
+        raise ValueError("Output FPS can't be greater than input FPS.")
+    gcd = math.gcd(input_fps, output_fps)
+    up = output_fps / gcd
+    down = input_fps / gcd
+    downsample = resample_poly(trace, up, down, axis=0, padtype="median")
+    return downsample

--- a/croissant/utils.py
+++ b/croissant/utils.py
@@ -125,11 +125,11 @@ def json_write_local_or_s3(obj, uri: str):
 
 
 def path_join_s3_os(path: str, to_join: str) -> str:
-    """Analogous to os.path.join that works regardless of for s3 
+    """Analogous to os.path.join that works regardless of for s3
     or file system. The format doesn't matter for Unix machines since
     both the web and file system use '/', but does matter for Windows
     since paths use '\'.
-    
+
     Parameters
     ----------
     path: str

--- a/croissant/utils.py
+++ b/croissant/utils.py
@@ -1,20 +1,22 @@
 """Miscellaneous utility functions that don't quite belong elsewhere."""
-from typing import Any, Union, Generator, List
+import math
 from functools import reduce
+import inspect
+import io
+import json
 import operator
-import boto3
+import os.path
+from typing import Any, Union, Generator, List
 from urllib.parse import urlparse
+
+import boto3
+from botocore.exceptions import ClientError
+import h5py
 from pathlib import Path
 import jsonlines
-import json
-import inspect
-from botocore.exceptions import ClientError
 import numpy as np
-import h5py
-import math
 from scipy.signal import resample_poly
-import io
-import os.path
+
 
 from croissant.roi import LimsRoiSchema
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ typing_extensions
 hyperopt
 hpsklearn
 scikit-image
+h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ hyperopt
 hpsklearn
 scikit-image
 h5py
+lims @ git+https://github.com/AllenInstitute/simple-lims-connection

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,9 @@ setup(
       url="https://github.com/AllenInstitute/croissant",
       packages=find_packages(),
       setup_requires=['setuptools_scm'],
-      install_requires=required,
+      install_requires=required + [
+          'lims @ git+https://github.com/AllenInstitute/simple-lims-connection'
+      ],
       python_requires='>=3.7.7',
       classifiers=[
           "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,7 @@ setup(
       url="https://github.com/AllenInstitute/croissant",
       packages=find_packages(),
       setup_requires=['setuptools_scm'],
-      install_requires=required + [
-          'lims @ git+https://github.com/AllenInstitute/simple-lims-connection'
-      ],
+      install_requires=required,
       python_requires='>=3.7.7',
       classifiers=[
           "Development Status :: 3 - Alpha",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,34 @@
+from typing import Tuple
+from pathlib import Path
+
+import pytest
+import h5py
+import numpy as np
+
+
+@pytest.fixture()
+def trace_file_fixture(tmp_path: Path, request) -> Tuple[Path, dict]:
+    """Fixture that allows parametrized optical physiology trace files
+    (*.h5) to be generated."""
+
+    trace_name = request.param.get("trace_filename", "mock_trace.h5")
+
+    trace_data = request.param.get("trace_data",
+                                   np.arange(100).reshape((5, 20)))
+    trace_data_key = request.param.get("trace_data_key", "data")
+
+    trace_names = request.param.get("trace_names", ['0', '4', '1', '3', '2'])
+    trace_names_key = request.param.get("trace_names_key", "roi_names")
+
+    fixture_params = {"trace_data": trace_data,
+                      "trace_data_key": trace_data_key,
+                      "trace_names": trace_names,
+                      "trace_names_key": trace_names_key}
+
+    trace_path = tmp_path / trace_name
+    with h5py.File(trace_path, "w") as f:
+        f[trace_data_key] = trace_data
+        formatted_trace_names = np.array(trace_names).astype(np.string_)
+        f.create_dataset(trace_names_key, data=formatted_trace_names)
+
+    return trace_path, fixture_params

--- a/test/scripts/test_annotation_ingest.py
+++ b/test/scripts/test_annotation_ingest.py
@@ -72,7 +72,7 @@ def test_annotation_job_schema_make_objects(
     """Test that the objects are properly loaded and turned into
     appropriate objects."""
     input_dict = {"slapp_upload_manifest_path": upload_manifest,
-                  "annotation_output_location": str(tmp_path),
+                  "annotation_output_manifest": str(tmp_path),
                   "labeling_project_key": "astley",
                   "annotation_id_key": "id",
                   "output_location": str(tmp_path)}
@@ -81,5 +81,3 @@ def test_annotation_job_schema_make_objects(
             schema_type=AnnotationIngestJobInput,
             input_data=input_dict, args=[])
         assert "manifest_data" in result.args
-
-

--- a/test/scripts/test_annotation_ingest.py
+++ b/test/scripts/test_annotation_ingest.py
@@ -1,0 +1,85 @@
+import json
+from contextlib import nullcontext as does_not_raise
+
+import argschema
+import marshmallow as mm
+import pytest
+
+from croissant.scripts.annotation_ingest import (
+    AnnotationIngestJobInput)
+
+
+@pytest.fixture
+def upload_manifest(request, tmp_path):
+    # Set up all the temp files
+    param = json.loads(request.param)
+    binarized_rois_path = tmp_path / param["binarized_rois_path"]
+    traces_h5_path = tmp_path / param["traces_h5_path"]
+    manifest_path = tmp_path / "upload_manifest.json"
+    manifest = param.copy()
+    manifest["binarized_rois_path"] = str(binarized_rois_path)
+    manifest["traces_h5_path"] = str(traces_h5_path)
+    with open(binarized_rois_path, "w") as f:
+        json.dump({}, f)
+    with open(traces_h5_path, "w") as f:
+        json.dump({}, f)
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f)
+    yield str(manifest_path)
+
+
+@pytest.fixture
+def metadata_query():
+    return [
+        {"movie_frame_rate_hz": 11.0,
+         "rig": "MESO.1",
+         "full_genotype": "Sst-IRES-Cre/wt;Ai148(TIT2L-GC6f-ICL-tTA2)/wt",
+         "id": 1060223946},
+        {"movie_frame_rate_hz": 11.0,
+         "rig": "MESO.1",
+         "full_genotype": "Sst-IRES-Cre/wt;Ai148(TIT2L-GC6f-ICL-tTA2)/wt",
+         "id": 1060223947}]
+
+
+@pytest.mark.parametrize(
+    "upload_manifest, context", [
+        (
+            """{
+                "experiment_id": 123,
+                "binarized_rois_path": "binarize.json",
+                "traces_h5_path": "trace.h5",
+                "local_to_global_roi_id_map": {
+                    "123": 444,
+                    "465": 999
+                },
+                "movie_path": "movie.h5",
+                "extra_field": "https://www.youtube.com/watch?v=oHg5SJYRHA0"
+            }""",
+            does_not_raise()
+        ),
+        (
+            """{
+                "experiment_id": 999,
+                "binarized_rois_path": "binarize.json",
+                "traces_h5_path": "trace.h5"
+            }""",
+            pytest.raises(mm.exceptions.ValidationError)
+        )], indirect=["upload_manifest"],
+    ids=["well_formed", "malformed"]
+)
+def test_annotation_job_schema_make_objects(
+        upload_manifest, context, tmp_path):
+    """Test that the objects are properly loaded and turned into
+    appropriate objects."""
+    input_dict = {"slapp_upload_manifest_path": upload_manifest,
+                  "annotation_output_location": str(tmp_path),
+                  "labeling_project_key": "astley",
+                  "annotation_id_key": "id",
+                  "output_location": str(tmp_path)}
+    with context:
+        result = argschema.ArgSchemaParser(
+            schema_type=AnnotationIngestJobInput,
+            input_data=input_dict, args=[])
+        assert "manifest_data" in result.args
+
+

--- a/test/test_train.py
+++ b/test/test_train.py
@@ -364,7 +364,7 @@ def s3_file():
     mock = mock_s3()
     mock.start()
     test_up = urlparse(file_uri)
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket=test_up.netloc)
     resp = s3.put_object(Bucket=test_up.netloc, Key=test_up.path[1:],
                          Body=json.dumps({'a': 1}).encode('utf-8'))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -63,7 +63,7 @@ def test_nested_get_item_fails_with_empty_list(d, keys):
 @mock_s3
 def test_s3_get_object():
     # Set up the fake bucket and object
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket="mybucket")
     body = b'{"a": 1}\n{"b": 2}'
     s3.put_object(Bucket="mybucket", Key="my/file.json",
@@ -76,7 +76,7 @@ def test_s3_get_object():
 @mock_s3
 def test_s3_fails_not_exist():
     # Set up the fake bucket and object
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket="mybucket")
     body = b'{"a": 1}\n{"b": 2}'
     s3.put_object(Bucket="mybucket", Key="my/file.json",
@@ -115,8 +115,8 @@ def test_read_jsonlines_file(tmp_path, body, expected):
     ]
 )
 def test_read_jsonlines_s3(body, expected):
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="mybucket")
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket="mybucket",)
     s3.put_object(Bucket="mybucket", Key="my/file.json",
                   Body=body)
     reader = read_jsonlines("s3://mybucket/my/file.json")
@@ -133,7 +133,7 @@ def test_json_load_local_or_s3(mode, expected, tmp_path):
     if mode == "s3":
         uri = "s3://myjsonbucket/my/file.json"
         up = urlparse(uri)
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", region_name="us-east-1")
         s3.create_bucket(Bucket=up.netloc)
         s3.put_object(Bucket=up.netloc, Key=up.path[1:],
                       Body=json.dumps(expected).encode('utf-8'))
@@ -169,7 +169,7 @@ def test_json_write_local_or_s3(mode, tmp_path):
 def test_object_exists():
     uri = "s3://myobjectbucket/my/file.json"
     up = urlparse(uri)
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket=up.netloc)
     s3.put_object(Bucket=up.netloc, Key=up.path[1:],
                   Body=json.dumps({'a': 1}).encode('utf-8'))


### PR DESCRIPTION
This isn't the greatest thing I've ever written, but it should allow us to automate generating training data from the artifacts created by the SLAPP transformer methods.

This does a few things:
1. Looks for all the raw data based on SLAPP transform manifests (which contain pointers to movies, local to global roi ID map, etc.)
2. Generates traces from the raw movies and COO matrix ROIs from the binarized output json
3. Pulls metadata using one DB query
4. Joins all the data together into (train + test) json that can be loaded by the croissant FeatureExtractor used for training.

I didn't write integration tests for the main script because it's really quite burdensome to set up and is dependent on SLAPP specifics. I think it's ok to punt on it for now. And because of the schematization we should catch problems pretty quickly when trying to generate training data, if anything changed.

Here's what the input json looks like, for the record:

```
{
        "annotation_output_manifest": "s3://prod.slapp.alleninstitute.org/behavior_slc_oct_2020/20201020135214/expert_output/ophys-experts-slc-oct-2020/manifests/output/output.manifest",
        "output_location": "s3://prod.slapp.alleninstitute.org/behavior_slc_oct_2020/20201020135214/expert_output/training_data/2020-11-04_11-10",
        "data_root_dir": "/allen/aibs/informatics/danielk/dev_LIMS/new_labeling_slapp_slc_trial_500",
        "labeling_project_key": "ophys-experts-slc-oct-2020",
        "annotation_id_key": "roi-id",
        "test_split": 0.3,
        "label_key": "majorityLabel",
        "label_map": {"cell": 1, "not cell": 0}
}
```

Example data: [S3](https://s3.console.aws.amazon.com/s3/buckets/prod.slapp.alleninstitute.org?region=us-west-2&prefix=behavior_slc_oct_2020/20201020135214/expert_output/training_data/2020-11-04_11-10/&showversions=false)

Is the proper format for FeatureExtractor (saved the data locally to avoid downloading again):
![Screen Shot 2020-11-04 at 2 46 48 PM](https://user-images.githubusercontent.com/34227334/98176037-9fd9ee80-1eac-11eb-8fd8-82154e8364d5.png)

For the record, out of 500 ROIs 104 were cell, or about 20%. I'm currently running 2 models (one with 3-fold CV, since the small size of the dataset may make it hard to find good hyperparameters with 5-fold).