### PR TITLE
separates out dependencies in extras

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           command: |
-            pip install .
+            pip install .[ALL,TEST]
           name: Install
       - run:
           command: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN git clone https://github.com/AllenInstitute/croissant
 RUN cd croissant && \
     git checkout ${MYBRANCH} && \
     conda env create -f conda.yaml -n myenv && \
-    conda run -n myenv pip install .
+    conda run -n myenv pip install .[ALL,TEST]
 
 RUN conda clean -ayv && \
     find /opt/conda -follow -type f -regextype posix-extended -regex '.*\.(pyc)' -delete

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,26 +9,28 @@ url = https://github.com/AllenInstitute/croissant
 [options]
 packages=find:
 install_requires = 
-    pytest
-    pytest-cov
-    pandas>=1.0.0
     scikit-learn>=0.23.1
     numpy
     scipy
+    scikit-image
+    pandas>=1.0.0
+    boto3
     argschema==2.0.2
+    h5py
+    jsonlines
+    typing_extensions
+
+[options.extras_require]
+ALL =
     setuptools
     mlflow==1.10.0
     tables
-    boto3
-    moto
-    jsonlines
     s3fs
     psycopg2-binary
-    typing_extensions
     hyperopt
     hpsklearn
-    scikit-image
-    h5py
-
-[options.extras_require]
+TEST =
+    pytest
+    pytest-cov
+    moto
 ONPREM = lims @ git+https://github.com/AllenInstitute/simple-lims-connection


### PR DESCRIPTION
shifts some dependencies in this repo to `ALL` and `TEST` extras_requires, so that a simple install (for inference) does not pull in s3fs.